### PR TITLE
fix(frontend): add missing validationStatus to goals test fixtures

### DIFF
--- a/frontend/src/stores/__tests__/goals.test.ts
+++ b/frontend/src/stores/__tests__/goals.test.ts
@@ -19,6 +19,7 @@ const sampleGoal = {
   category: 'Health',
   targetDate: '2025-06-01',
   status: 'IN_PROGRESS' as const,
+  validationStatus: null,
   totalMilestones: 2,
   completedMilestones: 1,
   milestones: [
@@ -54,6 +55,7 @@ const sampleGoal2 = {
   category: 'Fitness',
   targetDate: null,
   status: 'COMPLETED' as const,
+  validationStatus: null,
   totalMilestones: 0,
   completedMilestones: 0,
   milestones: [],


### PR DESCRIPTION
## Summary
- Adds missing \`validationStatus: null\` to two mock \`Goal\` objects in \`goals.test.ts\` (lines ~209 and ~234)
- Fixes TypeScript build failure on \`main\` CI

## Test Plan
- [ ] \`npm run test:unit\` passes (all tests green)
- [ ] \`npm run lint\` clean
- [ ] CI build passes on this branch