### PR TITLE
#33 ci: fix Renovate — pass token via with and set RENOVATE_REPOSITORIES

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Run Renovate
         uses: renovatebot/github-action@v46.1.3
         with:
+          token: ${{ secrets.GH_CONFIG_TOKEN }}
           configurationFile: renovate.json
         env:
-          RENOVATE_TOKEN: ${{ secrets.GH_CONFIG_TOKEN }}
+          RENOVATE_REPOSITORIES: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- Pass `token` via the `with` block (required by the action, env var alone doesn't work)
- Set `RENOVATE_REPOSITORIES` to the current repo so Renovate knows what to scan
- Fixes: `WARN: No repositories found — did you want to run with flag --autodiscover?`

## Test Plan
- [ ] Trigger Renovate workflow manually after merge and confirm it scans the repo and opens/updates the dependency PR