### PR TITLE
#43 ci: remove Snyk from PR/push workflows, consolidate into weekly scan

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -47,40 +47,4 @@ if [ -d "infra" ]; then
     echo ">> Terraform checks passed."
 fi
 
-# Snyk vulnerability scan
-if command -v snyk &> /dev/null; then
-    echo ">> Running Snyk vulnerability scan..."
-
-    snyk_check() {
-        local label=$1; shift
-        set +e
-        local out; out=$(snyk test "$@" 2>&1); local code=$?
-        set -e
-        echo "$out"
-        if echo "$out" | grep -qiE "test limit|usage limit|upgrade.*plan|snyk.*plans"; then
-            echo "WARN: Snyk $label limit reached — skipping scan."
-            return 0
-        fi
-        if [ $code -eq 1 ]; then
-            echo "!! Snyk found high/critical vulnerabilities in $label. Fix them before pushing."
-            exit 1
-        fi
-    }
-
-    if [ -d "backend" ]; then
-        echo "   Scanning backend dependencies..."
-        snyk_check backend --file=backend/pom.xml --severity-threshold=high --policy-path=.snyk
-    fi
-
-    if [ -d "frontend" ] && [ -f "frontend/package.json" ]; then
-        echo "   Scanning frontend dependencies..."
-        snyk_check frontend --file=frontend/package.json --severity-threshold=high --policy-path=.snyk
-    fi
-
-    echo ">> Snyk scan passed."
-else
-    echo ">> Snyk CLI not installed, skipping vulnerability scan."
-    echo "   Install with: npm install -g snyk && snyk auth"
-fi
-
 echo "=== All pre-push checks passed ==="

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -122,53 +122,6 @@ jobs:
           working_directory: infra
           soft_fail: true
 
-  security:
-    name: Security Scan
-    runs-on: ubuntu-latest
-    needs: [backend, frontend]
-    if: needs.backend.result == 'success' && needs.frontend.result == 'success'
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Node 20
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Setup Snyk
-        uses: snyk/actions/setup@master
-
-      - name: Snyk test backend
-        if: needs.backend.result == 'success'
-        working-directory: backend
-        run: |
-          if [ -z "$SNYK_TOKEN" ]; then echo "SNYK_TOKEN not set, skipping" && exit 0; fi
-          out=$(snyk test --file=pom.xml --severity-threshold=high 2>&1); code=$?
-          echo "$out"
-          if echo "$out" | grep -qiE "test limit|usage limit|upgrade.*plan|snyk.*plans"; then
-            echo "WARN: Snyk test limit reached — skipping backend scan."; exit 0
-          fi
-          if [ $code -eq 1 ]; then echo "Snyk found vulnerabilities" && exit 1; fi
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-
-      - name: Snyk test frontend
-        if: needs.frontend.result == 'success'
-        working-directory: frontend
-        run: |
-          if [ -z "$SNYK_TOKEN" ]; then echo "SNYK_TOKEN not set, skipping" && exit 0; fi
-          out=$(snyk test --file=package.json --severity-threshold=high 2>&1); code=$?
-          echo "$out"
-          if echo "$out" | grep -qiE "test limit|usage limit|upgrade.*plan|snyk.*plans"; then
-            echo "WARN: Snyk test limit reached — skipping frontend scan."; exit 0
-          fi
-          if [ $code -eq 1 ]; then echo "Snyk found vulnerabilities" && exit 1; fi
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-
   sonar:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest

--- a/.github/workflows/snyk-monitor.yml
+++ b/.github/workflows/snyk-monitor.yml
@@ -1,19 +1,26 @@
-name: Snyk Monitor
+name: Snyk Weekly Security
 
 on:
   schedule:
-    - cron: '0 3 * * *'  # 03:00 UTC daily
+    - cron: '0 3 * * 1'  # Monday 03:00 UTC
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  monitor:
-    name: Snyk Dependency Monitoring
+  snyk:
+    name: Snyk Test & Monitor
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
 
       - name: Set up Node 20
         uses: actions/setup-node@v4
@@ -22,17 +29,45 @@ jobs:
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
       - name: Setup Snyk
         uses: snyk/actions/setup@master
 
-      - name: Monitor backend
+      - name: Snyk test backend
+        working-directory: backend
+        run: |
+          out=$(snyk test --file=pom.xml --severity-threshold=high --policy-path=../.snyk 2>&1); code=$?
+          echo "$out"
+          if echo "$out" | grep -qiE "test limit|usage limit|upgrade.*plan|snyk.*plans"; then
+            echo "WARN: Snyk test limit reached — skipping backend test."; exit 0
+          fi
+          if [ $code -eq 1 ]; then echo "Snyk found high/critical vulnerabilities in backend" && exit 1; fi
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+      - name: Snyk test frontend
+        working-directory: frontend
+        run: |
+          out=$(snyk test --file=package.json --severity-threshold=high --policy-path=../.snyk 2>&1); code=$?
+          echo "$out"
+          if echo "$out" | grep -qiE "test limit|usage limit|upgrade.*plan|snyk.*plans"; then
+            echo "WARN: Snyk test limit reached — skipping frontend test."; exit 0
+          fi
+          if [ $code -eq 1 ]; then echo "Snyk found high/critical vulnerabilities in frontend" && exit 1; fi
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+      - name: Snyk monitor backend
         working-directory: backend
         continue-on-error: true
         run: snyk monitor --file=pom.xml --project-name=mindtrack-backend
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
-      - name: Monitor frontend
+      - name: Snyk monitor frontend
         working-directory: frontend
         continue-on-error: true
         run: snyk monitor --file=package.json --project-name=mindtrack-frontend

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -108,44 +108,6 @@ jobs:
           working_directory: infra
           soft_fail: true
 
-  security-scan:
-    name: Security Scan
-    runs-on: ubuntu-latest
-    needs: [backend-verify, frontend-verify]
-    if: always()
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Node 20
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Setup Snyk
-        uses: snyk/actions/setup@master
-
-      - name: Snyk test backend
-        working-directory: backend
-        run: |
-          if [ -z "$SNYK_TOKEN" ]; then echo "SNYK_TOKEN not set, skipping" && exit 0; fi
-          snyk test --file=pom.xml --severity-threshold=high; code=$?
-          if [ $code -eq 1 ]; then echo "Snyk found vulnerabilities" && exit 1; fi
-          if [ $code -eq 2 ]; then echo "Snyk scan skipped (quota/API error)" && exit 0; fi
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-
-      - name: Snyk test frontend
-        working-directory: frontend
-        run: |
-          if [ -z "$SNYK_TOKEN" ]; then echo "SNYK_TOKEN not set, skipping" && exit 0; fi
-          snyk test --file=package.json --severity-threshold=high; code=$?
-          if [ $code -eq 1 ]; then echo "Snyk found vulnerabilities" && exit 1; fi
-          if [ $code -eq 2 ]; then echo "Snyk scan skipped (quota/API error)" && exit 0; fi
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-
   sonar:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Removed Snyk `security` job from `feature.yml` — no longer runs on every PR
- Removed Snyk `security-scan` job from `verify.yml` — no longer runs on every push to main
- Removed Snyk block from `.githooks/pre-push` — no longer runs on every local push
- Updated `snyk-monitor.yml` → **weekly on Monday 03:00 UTC**, runs `snyk test` (with limit-error handling) then `snyk monitor` for both backend and frontend; added Java 21 setup so Maven can resolve backend dependencies

## Test Plan
- [ ] Confirm PR CI no longer includes a Security Scan job
- [ ] Trigger `Snyk Weekly Security` manually via workflow_dispatch and confirm test + monitor both run