### PR TITLE
#45 ci: enable GitHub security hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,79 @@
+version: 2
+
+updates:
+  # Backend — Maven
+  - package-ecosystem: "maven"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      backend-dependencies:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+    labels:
+      - "dependencies"
+      - "backend"
+    commit-message:
+      prefix: "chore(backend)"
+
+  # Frontend — npm
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      frontend-dependencies:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+    labels:
+      - "dependencies"
+      - "frontend"
+    commit-message:
+      prefix: "chore(frontend)"
+
+  # Infrastructure — Terraform
+  - package-ecosystem: "terraform"
+    directory: "/infra"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      infra-dependencies:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "infra"
+    commit-message:
+      prefix: "chore(infra)"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      actions-dependencies:
+        patterns:
+          - "*"
+        # Exclude the Claude code review action — managed manually to avoid
+        # OIDC validation failures when code-review.yml is modified in a PR.
+        exclude-patterns:
+          - "anthropics/claude-code-action"
+    ignore:
+      - dependency-name: "anthropics/claude-code-action"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/branch-check.yml
+++ b/.github/workflows/branch-check.yml
@@ -20,6 +20,10 @@ jobs:
             echo "Renovate branch — skipping convention check."
             exit 0
           fi
+          if [[ "$BRANCH" == dependabot/* ]]; then
+            echo "Dependabot branch — skipping convention check."
+            exit 0
+          fi
           PATTERN="^(feature|bugfix|chore|docs|test|refactor|ci|infra|style|perf|build)/[0-9]+-[a-z0-9-]+$"
           if [[ "$BRANCH" =~ $PATTERN ]]; then
             echo "Branch '$BRANCH' follows naming convention."

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Sunday 04:00 UTC — offset from Snyk (Monday 03:00) to spread load
+    - cron: '0 4 * * 0'
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: java-kotlin
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,30 @@
+name: Dependency Submission
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'backend/pom.xml'
+      - 'backend/**/pom.xml'
+
+permissions:
+  contents: write
+
+jobs:
+  submit:
+    name: Submit Maven Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Submit Maven Dependency Snapshot
+        uses: advanced-security/maven-dependency-submission-action@v4
+        with:
+          directory: backend

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,56 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release of MindTrack receives security updates.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest  | ✅        |
+| Older   | ❌        |
+
+## Reporting a Vulnerability
+
+MindTrack uses **GitHub private vulnerability reporting**.
+
+1. Navigate to the [Security Advisories](https://github.com/lucasrudi/mindtrack/security/advisories/new) page
+2. Click **"Report a vulnerability"**
+3. Fill in the type, affected versions, impact, and reproduction steps
+
+Reports are kept private until a fix is released. You can expect:
+
+- **Acknowledgment within 48 hours**
+- **Status update within 7 days**
+- **CVE assignment** for confirmed, exploitable vulnerabilities
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+## Security Features
+
+| Feature | Status |
+| ------- | ------ |
+| Dependabot security updates | ✅ Enabled — automatic PRs for vulnerable dependencies |
+| Dependabot alerts | ✅ Enabled — alerts on vulnerable dependencies |
+| Secret scanning | ✅ Enabled — detects accidentally committed secrets |
+| Secret push protection | ✅ Enabled — blocks pushes containing secrets |
+| CodeQL scanning | ✅ Enabled — static analysis for Java and JavaScript/TypeScript |
+| Dependency review | ✅ Enabled — blocks PRs introducing vulnerable dependencies |
+
+## Scope
+
+In-scope security issues:
+
+- Authentication and authorization bypasses
+- Injection vulnerabilities (SQL, XSS, LDAP, SSTI, command injection)
+- Insecure direct object references
+- Sensitive data exposure (mental health records, PII)
+- SSRF, XXE, and unsafe deserialization
+- Dependency vulnerabilities rated HIGH or CRITICAL
+
+## Out of Scope
+
+- Issues requiring physical access to a device
+- Third-party dependency vulnerabilities with no upstream fix
+- Rate limiting without demonstrated impact
+- Self-XSS
+- Issues only affecting outdated, unsupported versions

--- a/infra/github-settings/main.tf
+++ b/infra/github-settings/main.tf
@@ -74,5 +74,7 @@ module "github" {
   })
   actions_variables = var.actions_variables
 
-  enable_branch_protection = true
+  enable_branch_protection           = true
+  enable_secret_scanning             = true
+  enable_dependabot_security_updates = true
 }

--- a/infra/modules/github/main.tf
+++ b/infra/modules/github/main.tf
@@ -35,6 +35,15 @@ resource "github_repository" "this" {
 
   vulnerability_alerts = true
 
+  security_and_analysis {
+    secret_scanning {
+      status = var.enable_secret_scanning ? "enabled" : "disabled"
+    }
+    secret_scanning_push_protection {
+      status = var.enable_secret_scanning ? "enabled" : "disabled"
+    }
+  }
+
   lifecycle {
     prevent_destroy = true
   }
@@ -67,6 +76,20 @@ resource "github_branch_protection" "main" {
 
   allows_deletions    = false
   allows_force_pushes = false
+}
+
+# ------------------------------------
+# Dependabot Security Updates
+# Automatically opens PRs to fix vulnerable dependencies.
+# Requires vulnerability_alerts = true on the repository.
+# ------------------------------------
+resource "github_repository_dependabot_security_updates" "this" {
+  count = var.enable_dependabot_security_updates ? 1 : 0
+
+  repository = github_repository.this.name
+  enabled    = true
+
+  depends_on = [github_repository.this]
 }
 
 # ------------------------------------

--- a/infra/modules/github/variables.tf
+++ b/infra/modules/github/variables.tf
@@ -97,6 +97,18 @@ variable "labels" {
   }
 }
 
+variable "enable_secret_scanning" {
+  description = "Enable secret scanning and push protection. Works on public repos without GitHub Advanced Security."
+  type        = bool
+  default     = true
+}
+
+variable "enable_dependabot_security_updates" {
+  description = "Enable Dependabot security updates (automatic PRs for vulnerable dependencies). Requires vulnerability_alerts = true."
+  type        = bool
+  default     = true
+}
+
 variable "actions_secrets" {
   description = "Map of GitHub Actions secrets to create (name => plaintext value). Values are sensitive."
   type        = map(string)


### PR DESCRIPTION
## Summary

- **SECURITY.md** — security policy with private vulnerability reporting instructions and a features table
- **dependabot.yml** — grouped weekly updates for maven/npm/terraform/github-actions; ignores major version bumps; excludes `anthropics/claude-code-action` from auto-update to avoid OIDC validation failures on `code-review.yml`
- **codeql.yml** — CodeQL scanning for Java and JavaScript/TypeScript on push, PRs, and weekly schedule; `security-and-quality` query suite; results published to Security tab
- **dependency-submission.yml** — submits Maven dependency graph on `pom.xml` changes, giving Dependabot an accurate view of transitive dependencies
- **branch-check.yml** — add `dependabot/*` exemption alongside existing `renovate/*` exemption
- **infra/modules/github** — Terraform: `security_and_analysis` block enables secret scanning + push protection; new `github_repository_dependabot_security_updates` resource enables automatic security-fix PRs; two new boolean variables (both default `true`)
- **infra/github-settings/main.tf** — explicitly passes `enable_secret_scanning = true` and `enable_dependabot_security_updates = true` to module

## Notes

- GitHub Config Sync (`github-config-sync.yml`) must be run after merge to apply the `security_and_analysis` Terraform changes (secret scanning, push protection, Dependabot security updates)
- Dependabot security update PRs will auto-merge via the existing `auto-merge.yml` + `auto-approve.yml` chain once Code Review passes

## Test plan

- [ ] CI passes (backend, frontend, infra-verify jobs)
- [ ] After merge: trigger GitHub Config Sync to verify Terraform applies without error
- [ ] Verify secret scanning and push protection are active in GitHub Settings → Security
- [ ] Verify Dependabot is enabled under GitHub Settings → Security

🤖 Generated with [Claude Code](https://claude.com/claude-code)