### PR TITLE
ci(renovate): fix PR creation by running CI on renovate branches

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -6,6 +6,7 @@ on:
       - 'feature/**'
       - 'bugfix/**'
       - 'chore/**'
+      - 'renovate/**'
   pull_request:
     branches:
       - main

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   renovate:
@@ -23,3 +24,4 @@ jobs:
           configurationFile: renovate.json
         env:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
+          LOG_LEVEL: debug

--- a/renovate.json
+++ b/renovate.json
@@ -31,8 +31,6 @@
     }
   ],
   "vulnerabilityAlerts": {
-    "enabled": true,
-    "labels": ["security"],
-    "automerge": true
+    "enabled": false
   }
 }


### PR DESCRIPTION
Closes #71

## Root cause

Renovate was pushing dependency-update branches daily but never opening PRs. Two issues:

**1. No CI on `renovate/**` branches → Renovate skips PR creation**

`feature.yml` only triggered on `feature/**`, `bugfix/**`, `chore/**`. Renovate branches (`renovate/all-dependencies`, `renovate/major-*`) got pushed but had zero status checks. `config:recommended` sets `prCreation: "not-pending"`, which Renovate interprets as "wait for status checks to resolve before creating the PR" — with no checks present, the state was ambiguous and Renovate treated it as still-pending, silently skipping PR creation.

Fix: add `renovate/**` to `feature.yml` push triggers so the full CI suite (backend, frontend, infra, sonar) runs when Renovate pushes a branch. Once checks pass, Renovate creates the PR and the existing auto-approve + auto-merge pipeline takes over.

**2. `vulnerabilityAlerts` warning on every run**

`renovate.json` had `vulnerabilityAlerts: { enabled: true }` but the `GH_CONFIG_TOKEN` lacks the `security_events` scope needed to read GitHub vulnerability alerts via the GraphQL API. This produced `WARN: Cannot access vulnerability alerts` on every run. Since Snyk already handles vulnerability scanning in CI, this feature is redundant.

Fix: disable `vulnerabilityAlerts` in `renovate.json`.

## Other changes

- Add `issues: write` permission to `renovate.yml` (Renovate needs this to update the Dependency Dashboard issue)
- Add `LOG_LEVEL: debug` env var to `renovate.yml` for easier future diagnosis

## Expected outcome after merge

1. Next daily Renovate run (or manual dispatch) pushes branches → CI runs → checks pass → Renovate creates PRs
2. Code Review workflow runs → Auto Approve approves → Auto Merge merges non-major updates automatically
3. Major updates (`breaking` label) get PRs that require manual review before merge
4. No more vulnerability alerts warning in Renovate logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)