### PR TITLE
fix(ci): remove no-op --delete-branch and switch squash to PR_BODY

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Enable auto-merge
-        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/infra/modules/github/main.tf
+++ b/infra/modules/github/main.tf
@@ -28,7 +28,7 @@ resource "github_repository" "this" {
   allow_auto_merge   = true
 
   squash_merge_commit_title   = "PR_TITLE"
-  squash_merge_commit_message = "COMMIT_MESSAGES"
+  squash_merge_commit_message = "PR_BODY"
 
   delete_branch_on_merge = true
 


### PR DESCRIPTION
## Summary

- `auto-merge.yml`: removes `--delete-branch` from `gh pr merge --auto --squash` — the flag is a no-op with `--auto` because `gh` tries to delete the branch immediately (while the PR is still open), silently fails, and GitHub's async auto-merge has no memory of the request. Branch deletion is already handled by `delete_branch_on_merge = true` on the repo.
- `infra/modules/github/main.tf`: changes `squash_merge_commit_message` from `"COMMIT_MESSAGES"` to `"PR_BODY"` — with `COMMIT_MESSAGES`, `Closes #N` gets buried inside a concatenated multi-bullet commit block that GitHub's auto-merge bot doesn't reliably parse. With `PR_BODY`, the squash commit body is the PR description verbatim, so `Closes #N` appears cleanly on its own line and is recognised by both the PR-body and commit-body issue-closing code paths.

## Context

PR #75 was merged successfully but the branch `docs/74-github-workflows` was not deleted and issue #74 was not auto-closed. Both were cleaned up manually. These two changes prevent recurrence.

Note: the Terraform change takes effect on the next `github-config-sync` run (daily 06:00 UTC, or trigger manually).

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)