### PR TITLE
ci: add weekly GitHub Actions cache cleanup workflow

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,64 @@
+name: Cleanup Actions Cache
+
+on:
+  schedule:
+    - cron: '0 3 * * 0'  # Weekly, Sunday 03:00 UTC
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  cleanup:
+    name: Delete Duplicate Caches
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Delete duplicate caches (keep newest per key)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          echo "Fetching all caches for $REPO..."
+
+          # Collect all pages into a single JSON array.
+          # --paginate applies --jq to each page, outputting one array per page;
+          # jq -s 'add // []' merges them into a single flat array.
+          all_caches=$(gh api "repos/$REPO/actions/caches?per_page=100" \
+            --paginate \
+            --jq '[.actions_caches[]]' \
+            | jq -s 'add // []')
+
+          total=$(echo "$all_caches" | jq 'length')
+          echo "Total caches: $total"
+
+          # For each key group, sort descending by created_at and select
+          # every entry after the first (i.e. all older duplicates) for deletion.
+          to_delete=$(echo "$all_caches" | jq -r '
+            group_by(.key)[] |
+            sort_by(.created_at) | reverse |
+            .[1:][] |
+            "\(.id)\t\(.key[:60])\t\(.size_in_bytes)"
+          ')
+
+          if [ -z "$to_delete" ]; then
+            echo "No duplicate caches found — nothing to delete."
+            exit 0
+          fi
+
+          deleted_count=0
+          freed_bytes=0
+
+          while IFS=$'\t' read -r cache_id key size; do
+            mb=$(( size / 1048576 ))
+            echo "  Deleting [$cache_id] ${key}... (${mb}MB)"
+            if gh api --method DELETE "repos/$REPO/actions/caches/$cache_id" 2>/dev/null; then
+              deleted_count=$(( deleted_count + 1 ))
+              freed_bytes=$(( freed_bytes + size ))
+            else
+              echo "  Warning: failed to delete cache $cache_id"
+            fi
+          done <<< "$to_delete"
+
+          echo ""
+          echo "Done: deleted $deleted_count duplicate caches, freed $(( freed_bytes / 1048576 ))MB."


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/cache-cleanup.yml` — runs weekly (Sunday 03:00 UTC) and on `workflow_dispatch`
- Fetches all Actions cache entries, groups by key, deletes all but the newest entry per key
- Uses `GITHUB_TOKEN` with `actions: write` permission — no extra secrets needed

## Why

The cache currently has 142 entries with 4× duplicates on every key (CodeQL Go, Maven, SonarCloud, npm), approaching the 10 GB limit. This caused `Failed to save: Unable to reserve cache with key codeql-dependencies-*` warnings and cache misses in CI.

Estimated immediate savings after first run: ~2 GB freed (3 redundant copies × ~240 MB CodeQL + Maven + npm + SonarCloud entries).

## Test plan

- [ ] Merge and trigger via **Actions → Cleanup Actions Cache → Run workflow**
- [ ] Verify run output shows caches deleted and MB freed
- [ ] Check [Actions → Caches](https://github.com/lucasrudi/mindtrack/actions/caches) — total count should drop from 142 to ~40 (one entry per unique key)

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)