### PR TITLE
ci(renovate): clean up orphan branches after each run

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,3 +25,34 @@ jobs:
         env:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           LOG_LEVEL: debug
+
+  cleanup-orphan-branches:
+    name: Delete Renovate Branches Without Open PRs
+    runs-on: ubuntu-latest
+    needs: renovate
+    if: always()
+    steps:
+      - name: Delete orphan renovate branches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Scanning for orphan renovate branches..."
+          gh api repos/${{ github.repository }}/branches \
+            --paginate \
+            --jq '.[].name | select(startswith("renovate/"))' | \
+          while read -r branch; do
+            pr_count=$(gh pr list \
+              --repo "${{ github.repository }}" \
+              --head "$branch" \
+              --state open \
+              --json number \
+              --jq 'length')
+            if [ "$pr_count" = "0" ]; then
+              echo "Deleting orphan branch: $branch"
+              gh api repos/${{ github.repository }}/git/refs/heads/$branch \
+                --method DELETE
+            else
+              echo "Keeping branch (has open PR): $branch"
+            fi
+          done
+          echo "Cleanup complete."


### PR DESCRIPTION
## Summary

- Adds a `cleanup-orphan-branches` job to `renovate.yml` that runs after every Renovate execution (including on failure, via `if: always()`)
- Finds every `renovate/*` branch with no open PR and deletes it via the GitHub API using `GITHUB_TOKEN`
- Deleted the 9 existing orphan branches immediately (no PRs were open for any of them)

## How it works

The cleanup job pages through all branches matching `renovate/*`, checks for open PRs on each, and calls `DELETE /repos/{owner}/{repo}/git/refs/heads/{branch}` for any branch with zero open PRs. Branches that have an open PR are left untouched.

`delete_branch_on_merge = true` (already set in Terraform) handles the post-merge case — this job covers the no-PR case.

## Test plan

- [ ] CI passes on this PR
- [ ] Verify the 9 orphan branches no longer appear on the [active branches page](https://github.com/lucasrudi/mindtrack/branches/active)
- [ ] Trigger the renovate workflow manually after merging to confirm the cleanup job runs and logs correctly

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)