### PR TITLE
infra(iam): scope Transcribe IAM resource to mindtrack-* prefix

### DIFF
--- a/infra/modules/iam/main.tf
+++ b/infra/modules/iam/main.tf
@@ -165,7 +165,9 @@ data "aws_iam_policy_document" "lambda_permissions" {
       "transcribe:StartTranscriptionJob",
       "transcribe:GetTranscriptionJob",
     ]
-    resources = ["*"]
+    resources = [
+      "arn:aws:transcribe:*:${data.aws_caller_identity.current.account_id}:transcription-job/${var.name_prefix}-*",
+    ]
   }
 
   # VPC networking for RDS access


### PR DESCRIPTION
## Summary
- Fixes L-5: IAM Transcribe action was granted on `*` resources
- Scopes Transcribe job ARN to `arn:aws:transcribe:*:${account}:transcription-job/${prefix}-*`
- Reduces blast radius of any Lambda credential compromise

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)