### PR TITLE
infra(iam): restrict OIDC trust to main branch and production environment (H-13)

### DIFF
--- a/infra/modules/iam/main.tf
+++ b/infra/modules/iam/main.tf
@@ -27,9 +27,12 @@ data "aws_iam_policy_document" "github_actions_trust" {
       values   = ["sts.amazonaws.com"]
     }
     condition {
-      test     = "StringLike"
+      test     = "StringEquals"
       variable = "token.actions.githubusercontent.com:sub"
-      values   = ["repo:${var.github_org}/${var.github_repo}:*"]
+      values = [
+        "repo:${var.github_org}/${var.github_repo}:ref:refs/heads/main",
+        "repo:${var.github_org}/${var.github_repo}:environment:production",
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

- **H-13:** Replace `StringLike` wildcard OIDC condition (`repo:org/repo:*`) with `StringEquals` restricted to `ref:refs/heads/main` and `environment:production`
- Previously any branch, PR, or Renovate workflow could assume the production AWS deployment role
- Now only `deploy.yml` (which uses the `production` GitHub environment) can assume the role

Closes #89

## Test plan

- [ ] `terraform validate` passes
- [ ] `terraform fmt -check -recursive` passes
- [ ] CI tflint/tfsec pass
- [ ] Deploy workflow (`environment: production`) still authenticates successfully after merge
- [ ] Feature branch CI cannot assume the production AWS role

🤖 Generated with [Claude Code](https://claude.com/claude-code)