### PR TITLE
#92 fix(ci): set correct SonarCloud project key to lucasrudi_mindtrack

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.projectKey=mindtrack
+sonar.projectKey=lucasrudi_mindtrack
 sonar.projectName=MindTrack
 sonar.organization=lucasrudi
 


### PR DESCRIPTION
## Summary

- Updates `sonar.projectKey` from `mindtrack` to `lucasrudi_mindtrack` in `sonar-project.properties`
- The project was imported via the SonarCloud GitHub App, which assigns the key as `<org>_<repo>` — the old key `mindtrack` caused scanner failures with "project not found"
- Verified: project `lucasrudi_mindtrack` exists in SonarCloud org `lucasrudi` and has a recent analysis baseline (2026-03-09)

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)