### PR TITLE
fix: pin Claude Code Review action to full SHA (#142)

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -20,7 +20,9 @@ jobs:
           fetch-depth: 0
 
       - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@v1
+        # This action validates that code-review.yml matches the default branch before
+        # exchanging its app token, so update this file in a dedicated workflow-only PR.
+        uses: anthropics/claude-code-action@5d0cc745cd0cce4c0e9e0b3511de26c3bc285eb5 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           direct_prompt: |


### PR DESCRIPTION
## Summary
- pin `anthropics/claude-code-action` to the verified commit behind tag `v1`
- add an inline workflow comment explaining the default-branch self-validation behavior

## Context
- follow-up to issue #142
- separated from the product/infra fixes merged in #141 so the workflow behavior is documented in the file itself

## Note
- this PR changes `.github/workflows/code-review.yml`, so the `Code Review` check may still require temporary handling until the updated workflow exists on `main`
