### PR TITLE
fix: repair GitHub config sync recovery (#144)

### DIFF
--- a/.github/workflows/github-config-sync.yml
+++ b/.github/workflows/github-config-sync.yml
@@ -21,6 +21,15 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    env:
+      GITHUB_OWNER: ${{ github.repository_owner }}
+      GITHUB_TOKEN: ${{ secrets.GH_CONFIG_TOKEN }}
+      # Keep these maps aligned with the secrets and variables currently managed
+      # in infra/github-settings Terraform state.
+      TF_VAR_actions_secrets: >-
+        {"GH_CONFIG_TOKEN":"${{ secrets.GH_CONFIG_TOKEN }}","SENTRY_AUTH_TOKEN":"${{ secrets.SENTRY_AUTH_TOKEN }}"}
+      TF_VAR_actions_variables: >-
+        {"SENTRY_ORG":"${{ vars.SENTRY_ORG }}","SENTRY_PROJECT_FRONTEND":"${{ vars.SENTRY_PROJECT_FRONTEND }}","VITE_SENTRY_DSN":"${{ vars.VITE_SENTRY_DSN }}","VITE_SENTRY_TRACES_SAMPLE_RATE":"${{ vars.VITE_SENTRY_TRACES_SAMPLE_RATE }}"}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -39,19 +48,21 @@ jobs:
         working-directory: infra/github-settings
         run: rm -rf .terraform
 
+      - name: Validate GH_CONFIG_TOKEN access
+        run: |
+          curl --fail --silent --show-error \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_OWNER/${{ github.event.repository.name }}/actions/variables?per_page=1" \
+            >/dev/null
+
       - name: Terraform Init
         working-directory: infra/github-settings
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_CONFIG_TOKEN }}
-          GITHUB_OWNER: ${{ github.repository_owner }}
         run: terraform init
 
       - name: Terraform Plan
         working-directory: infra/github-settings
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_CONFIG_TOKEN }}
-          GITHUB_OWNER: ${{ github.repository_owner }}
-          TF_VAR_actions_secrets: '{"GH_CONFIG_TOKEN":"${{ secrets.GH_CONFIG_TOKEN }}"}'
         run: |
           terraform plan \
             -var="repository_name=${{ github.event.repository.name }}" \
@@ -59,8 +70,4 @@ jobs:
 
       - name: Terraform Apply
         working-directory: infra/github-settings
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_CONFIG_TOKEN }}
-          GITHUB_OWNER: ${{ github.repository_owner }}
-          TF_VAR_actions_secrets: '{"GH_CONFIG_TOKEN":"${{ secrets.GH_CONFIG_TOKEN }}"}'
         run: terraform apply tfplan

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -209,20 +209,16 @@ The deploy workflow (`deploy.yml`) uses `role-to-assume: ${{ vars.AWS_ROLE_ARN }
 
 ### GitHub Repository Secrets
 
-GitHub Actions secrets and variables are managed via Terraform (see `infra/modules/github/`). Pass them when applying:
+GitHub Actions secrets and variables can be managed via Terraform (see `infra/modules/github/`). Only include entries you want Terraform to own, and keep that set aligned with [github-config-sync.yml](/Users/lucasrudi/dev/claude-first-test/.github/workflows/github-config-sync.yml). The current managed set is the GitHub config PAT, the frontend Sentry upload token, and the frontend Sentry variables:
 
 ```bash
 terraform -chdir=infra/github-settings apply \
   -var='repository_name=<your-repo-name>' \
   -var='actions_secrets={
     "GH_CONFIG_TOKEN":"<github-pat>",
-    "SONAR_TOKEN":"<sonar-token>",
-    "SNYK_TOKEN":"<snyk-token>",
-    "ANTHROPIC_API_KEY":"<anthropic-key>",
     "SENTRY_AUTH_TOKEN":"<sentry-auth-token>"
   }' \
   -var='actions_variables={
-    "AWS_ROLE_ARN":"<aws-role-arn>",
     "SENTRY_ORG":"<sentry-org-slug>",
     "SENTRY_PROJECT_FRONTEND":"<frontend-project-slug>",
     "VITE_SENTRY_DSN":"<frontend-dsn>",
@@ -230,17 +226,21 @@ terraform -chdir=infra/github-settings apply \
   }'
 ```
 
+Keep [github-config-sync.yml](/Users/lucasrudi/dev/claude-first-test/.github/workflows/github-config-sync.yml) aligned with the secrets and variables you manage here. The scheduled/manual GitHub Config Sync workflow can only preserve the secret and variable names it passes into `TF_VAR_actions_secrets` and `TF_VAR_actions_variables`.
+
 Or configure manually in **Settings** > **Secrets and variables** > **Actions**:
 
 **Secrets:**
 
 | Secret | Source | Purpose |
 |--------|--------|---------|
+| `GH_CONFIG_TOKEN` | GitHub PAT; prefer a classic PAT with `repo` scope | Renovate and GitHub settings Terraform (`github-config-sync.yml`) |
 | `SONAR_TOKEN` | [SonarCloud](https://sonarcloud.io/) > My Account > Security | Code quality analysis |
 | `SNYK_TOKEN` | [Snyk](https://app.snyk.io/) > Account settings | Vulnerability scanning |
 | `ANTHROPIC_API_KEY` | [Anthropic Console](https://console.anthropic.com/) > API Keys | Claude code-review in CI |
 | `SENTRY_AUTH_TOKEN` | [Sentry](https://sentry.io/settings/auth-tokens/) | Frontend release/source-map upload during deploy |
-| `RENOVATE_TOKEN` | GitHub PAT (classic) with `repo` scope | Renovate dependency updates |
+
+`SONAR_TOKEN`, `SNYK_TOKEN`, and `ANTHROPIC_API_KEY` are currently configured manually in GitHub Actions. If you later move them under Terraform management, add them to both the local/apply secret map and [github-config-sync.yml](/Users/lucasrudi/dev/claude-first-test/.github/workflows/github-config-sync.yml) in the same change.
 
 **Variables:**
 
@@ -255,6 +255,16 @@ Or configure manually in **Settings** > **Secrets and variables** > **Actions**:
 | `VITE_SENTRY_TRACES_SAMPLE_RATE` | `0.1` | Frontend Sentry tracing sample rate |
 | `VITE_APP_ENV` | `production` | Environment label in Sentry (hardcoded in deploy.yml) |
 | `VITE_GA_MEASUREMENT_ID` | `G-XXXXXXXXXX` | GA4 Measurement ID (injected at build time) |
+
+### GitHub Config Sync Recovery
+
+If a temporary manual branch-protection change or an under-scoped `GH_CONFIG_TOKEN` breaks `GitHub Config Sync`, recover with this sequence:
+
+1. Refresh `GH_CONFIG_TOKEN` with a PAT that can access repository Actions variables. A classic PAT with `repo` scope is the lowest-friction option.
+2. Confirm which GitHub Actions secrets and variables are currently managed in `infra/github-settings` state before applying locally.
+3. Run a local `terraform plan` / `terraform apply` in `infra/github-settings` using a working `GITHUB_TOKEN` plus the full current `actions_secrets` and `actions_variables` maps.
+4. Check `main` branch protection again after apply so the required checks and approval count are restored.
+5. Trigger `.github/workflows/github-config-sync.yml` manually to verify CI can now manage the repo without local recovery.
 
 > See [Environment Variables](environment-variables.md) for the complete reference of all application and CI environment variables.
 

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -283,9 +283,32 @@ Uses the `advanced-security/maven-dependency-submission-action` to populate the 
 
 Reuses the repository `GH_CONFIG_TOKEN` secret for GitHub provider auth and the `AWS_ROLE_ARN` Actions variable for OIDC access to the Terraform backend. Runs Terraform plan + apply against the `infra/github-settings/` root module.
 
+Important behavior: the workflow passes the currently Terraform-managed GitHub Actions secrets and variables into `TF_VAR_actions_secrets` and `TF_VAR_actions_variables` before planning. When you add a new Terraform-managed Actions secret or variable, update [github-config-sync.yml](/Users/lucasrudi/dev/claude-first-test/.github/workflows/github-config-sync.yml) in the same PR so the scheduled/manual sync job keeps the full input map and does not plan accidental destroys.
+
+`GH_CONFIG_TOKEN` must be able to read and write repository Actions variables in addition to the branch-protection and repository settings Terraform already manages. The simplest supported setup is a classic PAT with `repo` scope. If you use a fine-grained PAT instead, verify it can successfully call the repository Actions variables API before storing it as `GH_CONFIG_TOKEN`.
+
 | Job | Steps |
 |-----|-------|
-| `sync` | AWS OIDC auth → Terraform setup → Terraform init/plan/apply |
+| `sync` | AWS OIDC auth → Terraform setup → validate `GH_CONFIG_TOKEN` against the Actions variables API → Terraform init/plan/apply |
+
+#### Troubleshooting
+
+If `GitHub Config Sync` fails during `terraform plan` with `403 Resource not accessible by personal access token`, use this checklist:
+
+1. Confirm the failing API path is under `/repos/{owner}/{repo}/actions/variables/...`; that points to an under-scoped `GH_CONFIG_TOKEN`, not broken Terraform state.
+2. Check whether the workflow input maps in [github-config-sync.yml](/Users/lucasrudi/dev/claude-first-test/.github/workflows/github-config-sync.yml) still include every secret and variable currently managed in `infra/github-settings` state.
+3. Verify `main` branch protection has not been left in a temporary manual state after a workflow bootstrap bypass.
+4. Refresh the `GH_CONFIG_TOKEN` secret with a token that can access repository Actions variables, then rerun the workflow.
+
+#### Recovery Runbook
+
+Use this runbook after a temporary branch-protection bypass or a broken `GH_CONFIG_TOKEN` leaves GitHub Config Sync unable to heal the repo automatically:
+
+1. Check the current live protection settings with `gh api repos/<owner>/<repo>/branches/main/protection/required_status_checks` and `gh api repos/<owner>/<repo>/branches/main/protection/required_pull_request_reviews`.
+2. If `GH_CONFIG_TOKEN` is under-scoped, replace the repository secret with a working PAT and update the AWS backup copy if you use that for manual recovery.
+3. Run a local `terraform plan` / `terraform apply` in `infra/github-settings` with a working `GITHUB_TOKEN` plus the full currently managed `actions_secrets` and `actions_variables` maps.
+4. Update [github-config-sync.yml](/Users/lucasrudi/dev/claude-first-test/.github/workflows/github-config-sync.yml) if the managed secret or variable set changed.
+5. Trigger `GitHub Config Sync` manually after the repair to confirm CI can manage the repo again without local intervention.
 
 ---
 


### PR DESCRIPTION
## Summary
- repair `github-config-sync.yml` so it passes the full currently managed GitHub Actions secret/variable set into Terraform
- add a preflight check that fails early when `GH_CONFIG_TOKEN` cannot read repository Actions variables
- document the bootstrap and recovery runbook for GitHub Config Sync and Code Review workflow changes

## Live repair completed
- restored `main` required status checks and the required approval count with a local Terraform apply
- refreshed `GH_CONFIG_TOKEN` in GitHub Actions and updated the AWS backup copy used for manual recovery
- verified a follow-up local Terraform plan in `infra/github-settings` returned `No changes`

## Issue
- closes #144
