### PR TITLE
fix(frontend): pin yauzl to 3.2.1

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4717,16 +4717,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
-    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -8141,14 +8131,17 @@
       "license": "ISC"
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.1.tgz",
+      "integrity": "sha512-k1isifdbpNSFEHFJ1ZY4YDewv0IH9FR61lDetaRMD3j2ae3bIXGV+7c+LHCqtQGofSd8PIyV4X6+dHMAnSr60A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "vue-router": "^4.0.0"
   },
   "overrides": {
+    "yauzl": "3.2.1",
     "editorconfig": {
       "minimatch": "9.0.9"
     }


### PR DESCRIPTION
## Summary
- add an npm override for `yauzl` in the frontend package manifest
- regenerate `frontend/package-lock.json` so Cypress resolves `yauzl@3.2.1`
- keep the change scoped to the frontend toolchain

## Verification
- `npm ls yauzl`
- `npm run test:unit -- --run`
- `npm run lint`
- pre-push hook (`mvn test -q -Djacoco.skip=true`, frontend checks, Terraform checks)

Closes #157