### PR TITLE
#177 fix(ci): add workflow_dispatch to Release and Verify workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   backend-verify:


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to `release.yml` so release-please can be triggered manually
- Add `workflow_dispatch` trigger to `verify.yml` for on-demand post-merge validation

## Problem

The Release and Verify workflows stopped triggering on push to `main` since March 14. Multiple feat commits landed (KMS encryption, GDPR data retention, Spring Boot 4 compat, rate limiting, JWT rotation) without a release-please PR being created. CodeQL (security scanning) continues to run unaffected.

Root cause: GitHub throttles `push` event dispatch to workflows when many PRs merge in rapid succession on a protected branch.

## After merge

Once merged, trigger the release manually:
```
gh workflow run release.yml
```
This will create the release-please PR with version bumps for all unreleased feat commits.

Closes #177