### PR TITLE
#181 fix(ci): skip AI review for release-please PRs

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -15,11 +15,22 @@ jobs:
     name: Code Review
     runs-on: ubuntu-latest
     steps:
+      - name: Skip review for release PR
+        if: github.head_ref == 'release-please--branches--main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --body "**Release PR** — auto-generated changelog and version bumps. No code review required. ✅"
+
       - uses: actions/checkout@v4
+        if: github.head_ref != 'release-please--branches--main'
         with:
           fetch-depth: 0
 
       - name: Run Claude Code Review
+        if: github.head_ref != 'release-please--branches--main'
         # This action validates that code-review.yml matches the default branch before
         # exchanging its app token, so update this file in a dedicated workflow-only PR.
         uses: anthropics/claude-code-action@5d0cc745cd0cce4c0e9e0b3511de26c3bc285eb5 # v1


### PR DESCRIPTION
## Summary
Skip the `claude-code-action` step for `release-please--branches--main` PRs and post a pass comment instead. Release PRs contain only auto-generated changelogs and version bumps — no code to review.

## Note on Code Review check

`claude-code-action` validates that `code-review.yml` on the PR branch matches the default branch before token exchange. **This check will fail on this PR** because we are modifying `code-review.yml` itself — this is expected and documented in the action's own error message. Admin merge required.

Closes #181