### PR TITLE
infra(rds): switch from Aurora Serverless v2 to RDS MySQL db.t3.micro

### DIFF
--- a/infra/environments/dev.tfvars
+++ b/infra/environments/dev.tfvars
@@ -1,7 +1,5 @@
 environment        = "dev"
 aws_region         = "us-east-1"
-db_min_capacity    = 0.5
-db_max_capacity    = 1
 lambda_memory_size = 512
 domain_name        = ""
 

--- a/infra/environments/prod.tfvars
+++ b/infra/environments/prod.tfvars
@@ -1,7 +1,5 @@
 environment        = "prod"
 aws_region         = "us-east-1"
-db_min_capacity    = 0.5
-db_max_capacity    = 4
 lambda_memory_size = 1024
 domain_name        = ""
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -32,8 +32,6 @@ module "rds" {
   source = "./modules/rds"
 
   name_prefix  = local.name_prefix
-  min_capacity = var.db_min_capacity
-  max_capacity = var.db_max_capacity
   lambda_sg_id = module.lambda.security_group_id
   vpc_id       = module.vpc.vpc_id
   subnet_ids   = module.vpc.private_subnet_ids
@@ -100,7 +98,6 @@ module "monitoring" {
   aws_region                 = var.aws_region
   lambda_function_name       = module.lambda.function_name
   api_gateway_id             = module.api_gateway.api_id
-  rds_cluster_identifier     = module.rds.cluster_identifier
   rds_instance_identifier    = module.rds.instance_identifier
   audio_bucket_name          = module.s3.audio_bucket_name
   frontend_bucket_name       = module.s3.frontend_bucket_name

--- a/infra/modules/monitoring/dashboard-database.tf
+++ b/infra/modules/monitoring/dashboard-database.tf
@@ -1,5 +1,5 @@
 # =============================================================================
-# Database Deep-Dive Dashboard — Aurora Serverless v2
+# Database Deep-Dive Dashboard — RDS MySQL
 # =============================================================================
 
 resource "aws_cloudwatch_dashboard" "database" {
@@ -7,7 +7,7 @@ resource "aws_cloudwatch_dashboard" "database" {
 
   dashboard_body = jsonencode({
     widgets = [
-      # ── Row 1: Capacity & CPU ───────────────────────────────────
+      # ── Row 1: CPU & Connections ─────────────────────────────────
       {
         type   = "metric"
         x      = 0
@@ -15,46 +15,12 @@ resource "aws_cloudwatch_dashboard" "database" {
         width  = 8
         height = 6
         properties = {
-          title  = "Serverless ACU Capacity"
-          region = var.aws_region
-          metrics = [
-            ["AWS/RDS", "ServerlessDatabaseCapacity", "DBClusterIdentifier", var.rds_cluster_identifier,
-            { stat = "Average", color = "#1f77b4", label = "Average ACU" }],
-            ["AWS/RDS", "ServerlessDatabaseCapacity", "DBClusterIdentifier", var.rds_cluster_identifier,
-            { stat = "Maximum", color = "#d62728", label = "Max ACU" }]
-          ]
-          view    = "timeSeries"
-          stacked = false
-          period  = 300
-          annotations = {
-            horizontal = [
-              {
-                label = "Min Capacity"
-                value = 0.5
-                color = "#2ca02c"
-              },
-              {
-                label = "Max Capacity"
-                value = 2
-                color = "#d62728"
-              }
-            ]
-          }
-        }
-      },
-      {
-        type   = "metric"
-        x      = 8
-        y      = 0
-        width  = 8
-        height = 6
-        properties = {
           title  = "CPU Utilization (%)"
           region = var.aws_region
           metrics = [
-            ["AWS/RDS", "CPUUtilization", "DBClusterIdentifier", var.rds_cluster_identifier,
+            ["AWS/RDS", "CPUUtilization", "DBInstanceIdentifier", var.rds_instance_identifier,
             { stat = "Average", color = "#1f77b4", label = "Average CPU" }],
-            ["AWS/RDS", "CPUUtilization", "DBClusterIdentifier", var.rds_cluster_identifier,
+            ["AWS/RDS", "CPUUtilization", "DBInstanceIdentifier", var.rds_instance_identifier,
             { stat = "Maximum", color = "#d62728", label = "Max CPU" }]
           ]
           view    = "timeSeries"
@@ -76,7 +42,7 @@ resource "aws_cloudwatch_dashboard" "database" {
       },
       {
         type   = "metric"
-        x      = 16
+        x      = 8
         y      = 0
         width  = 8
         height = 6
@@ -84,14 +50,41 @@ resource "aws_cloudwatch_dashboard" "database" {
           title  = "Database Connections"
           region = var.aws_region
           metrics = [
-            ["AWS/RDS", "DatabaseConnections", "DBClusterIdentifier", var.rds_cluster_identifier,
+            ["AWS/RDS", "DatabaseConnections", "DBInstanceIdentifier", var.rds_instance_identifier,
             { stat = "Average", color = "#1f77b4", label = "Average" }],
-            ["AWS/RDS", "DatabaseConnections", "DBClusterIdentifier", var.rds_cluster_identifier,
+            ["AWS/RDS", "DatabaseConnections", "DBInstanceIdentifier", var.rds_instance_identifier,
             { stat = "Maximum", color = "#d62728", label = "Maximum" }]
           ]
           view    = "timeSeries"
           stacked = false
           period  = 300
+        }
+      },
+      {
+        type   = "metric"
+        x      = 16
+        y      = 0
+        width  = 8
+        height = 6
+        properties = {
+          title  = "Free Storage Space (bytes)"
+          region = var.aws_region
+          metrics = [
+            ["AWS/RDS", "FreeStorageSpace", "DBInstanceIdentifier", var.rds_instance_identifier,
+            { stat = "Minimum", color = "#2ca02c", label = "Free Storage" }]
+          ]
+          view    = "timeSeries"
+          stacked = false
+          period  = 300
+          annotations = {
+            horizontal = [
+              {
+                label = "Alarm Threshold (2 GB)"
+                value = 2147483648
+                color = "#d62728"
+              }
+            ]
+          }
         }
       },
 
@@ -106,9 +99,9 @@ resource "aws_cloudwatch_dashboard" "database" {
           title  = "Read / Write Latency (ms)"
           region = var.aws_region
           metrics = [
-            ["AWS/RDS", "ReadLatency", "DBClusterIdentifier", var.rds_cluster_identifier,
+            ["AWS/RDS", "ReadLatency", "DBInstanceIdentifier", var.rds_instance_identifier,
             { stat = "Average", color = "#1f77b4", label = "Read Latency" }],
-            ["AWS/RDS", "WriteLatency", "DBClusterIdentifier", var.rds_cluster_identifier,
+            ["AWS/RDS", "WriteLatency", "DBInstanceIdentifier", var.rds_instance_identifier,
             { stat = "Average", color = "#ff7f0e", label = "Write Latency" }]
           ]
           view    = "timeSeries"
@@ -126,9 +119,9 @@ resource "aws_cloudwatch_dashboard" "database" {
           title  = "Read / Write IOPS"
           region = var.aws_region
           metrics = [
-            ["AWS/RDS", "ReadIOPS", "DBClusterIdentifier", var.rds_cluster_identifier,
+            ["AWS/RDS", "ReadIOPS", "DBInstanceIdentifier", var.rds_instance_identifier,
             { stat = "Average", color = "#1f77b4", label = "Read IOPS" }],
-            ["AWS/RDS", "WriteIOPS", "DBClusterIdentifier", var.rds_cluster_identifier,
+            ["AWS/RDS", "WriteIOPS", "DBInstanceIdentifier", var.rds_instance_identifier,
             { stat = "Average", color = "#ff7f0e", label = "Write IOPS" }]
           ]
           view    = "timeSeries"
@@ -146,9 +139,9 @@ resource "aws_cloudwatch_dashboard" "database" {
           title  = "Read / Write Throughput (bytes/s)"
           region = var.aws_region
           metrics = [
-            ["AWS/RDS", "ReadThroughput", "DBClusterIdentifier", var.rds_cluster_identifier,
+            ["AWS/RDS", "ReadThroughput", "DBInstanceIdentifier", var.rds_instance_identifier,
             { stat = "Average", color = "#1f77b4", label = "Read" }],
-            ["AWS/RDS", "WriteThroughput", "DBClusterIdentifier", var.rds_cluster_identifier,
+            ["AWS/RDS", "WriteThroughput", "DBInstanceIdentifier", var.rds_instance_identifier,
             { stat = "Average", color = "#ff7f0e", label = "Write" }]
           ]
           view    = "timeSeries"
@@ -157,28 +150,10 @@ resource "aws_cloudwatch_dashboard" "database" {
         }
       },
 
-      # ── Row 3: Storage & Memory ─────────────────────────────────
+      # ── Row 3: Memory & Disk ─────────────────────────────────────
       {
         type   = "metric"
         x      = 0
-        y      = 12
-        width  = 8
-        height = 6
-        properties = {
-          title  = "Aurora Storage (bytes)"
-          region = var.aws_region
-          metrics = [
-            ["AWS/RDS", "VolumeBytesUsed", "DBClusterIdentifier", var.rds_cluster_identifier,
-            { stat = "Average", color = "#1f77b4", label = "Volume Size" }]
-          ]
-          view    = "timeSeries"
-          stacked = false
-          period  = 3600
-        }
-      },
-      {
-        type   = "metric"
-        x      = 8
         y      = 12
         width  = 8
         height = 6
@@ -196,27 +171,44 @@ resource "aws_cloudwatch_dashboard" "database" {
       },
       {
         type   = "metric"
+        x      = 8
+        y      = 12
+        width  = 8
+        height = 6
+        properties = {
+          title  = "Disk Queue Depth"
+          region = var.aws_region
+          metrics = [
+            ["AWS/RDS", "DiskQueueDepth", "DBInstanceIdentifier", var.rds_instance_identifier,
+            { stat = "Average", color = "#9467bd", label = "Queue Depth" }]
+          ]
+          view    = "timeSeries"
+          stacked = false
+          period  = 300
+        }
+      },
+      {
+        type   = "metric"
         x      = 16
         y      = 12
         width  = 8
         height = 6
         properties = {
-          title  = "Buffer Cache Hit Ratio (%)"
+          title  = "Network Throughput (bytes/s)"
           region = var.aws_region
           metrics = [
-            ["AWS/RDS", "BufferCacheHitRatio", "DBClusterIdentifier", var.rds_cluster_identifier,
-            { stat = "Average", color = "#2ca02c", label = "Cache Hit %" }]
+            ["AWS/RDS", "NetworkReceiveThroughput", "DBInstanceIdentifier", var.rds_instance_identifier,
+            { stat = "Average", color = "#1f77b4", label = "Receive" }],
+            ["AWS/RDS", "NetworkTransmitThroughput", "DBInstanceIdentifier", var.rds_instance_identifier,
+            { stat = "Average", color = "#ff7f0e", label = "Transmit" }]
           ]
           view    = "timeSeries"
           stacked = false
           period  = 300
-          yAxis = {
-            left = { min = 0, max = 100 }
-          }
         }
       },
 
-      # ── Row 4: DML & Deadlocks ─────────────────────────────────
+      # ── Row 4: Errors ─────────────────────────────────────────
       {
         type   = "metric"
         x      = 0
@@ -224,36 +216,12 @@ resource "aws_cloudwatch_dashboard" "database" {
         width  = 12
         height = 6
         properties = {
-          title  = "DML Throughput (operations/s)"
-          region = var.aws_region
-          metrics = [
-            ["AWS/RDS", "SelectThroughput", "DBClusterIdentifier", var.rds_cluster_identifier,
-            { stat = "Average", color = "#1f77b4", label = "SELECT" }],
-            ["AWS/RDS", "InsertThroughput", "DBClusterIdentifier", var.rds_cluster_identifier,
-            { stat = "Average", color = "#2ca02c", label = "INSERT" }],
-            ["AWS/RDS", "UpdateThroughput", "DBClusterIdentifier", var.rds_cluster_identifier,
-            { stat = "Average", color = "#ff7f0e", label = "UPDATE" }],
-            ["AWS/RDS", "DeleteThroughput", "DBClusterIdentifier", var.rds_cluster_identifier,
-            { stat = "Average", color = "#d62728", label = "DELETE" }]
-          ]
-          view    = "timeSeries"
-          stacked = false
-          period  = 300
-        }
-      },
-      {
-        type   = "metric"
-        x      = 12
-        y      = 18
-        width  = 12
-        height = 6
-        properties = {
           title  = "Deadlocks & Aborted Connections"
           region = var.aws_region
           metrics = [
-            ["AWS/RDS", "Deadlocks", "DBClusterIdentifier", var.rds_cluster_identifier,
+            ["AWS/RDS", "Deadlocks", "DBInstanceIdentifier", var.rds_instance_identifier,
             { stat = "Sum", color = "#d62728", label = "Deadlocks" }],
-            ["AWS/RDS", "AbortedClients", "DBClusterIdentifier", var.rds_cluster_identifier,
+            ["AWS/RDS", "AbortedClients", "DBInstanceIdentifier", var.rds_instance_identifier,
             { stat = "Sum", color = "#ff7f0e", label = "Aborted Clients" }]
           ]
           view    = "timeSeries"

--- a/infra/modules/monitoring/dashboard-overview.tf
+++ b/infra/modules/monitoring/dashboard-overview.tf
@@ -59,12 +59,12 @@ resource "aws_cloudwatch_dashboard" "main" {
         width  = 6
         height = 6
         properties = {
-          title  = "RDS Aurora — CPU & Connections"
+          title  = "RDS MySQL — CPU & Connections"
           region = var.aws_region
           metrics = [
-            ["AWS/RDS", "CPUUtilization", "DBClusterIdentifier", var.rds_cluster_identifier,
+            ["AWS/RDS", "CPUUtilization", "DBInstanceIdentifier", var.rds_instance_identifier,
             { stat = "Average", color = "#1f77b4", label = "CPU %" }],
-            ["AWS/RDS", "DatabaseConnections", "DBClusterIdentifier", var.rds_cluster_identifier,
+            ["AWS/RDS", "DatabaseConnections", "DBInstanceIdentifier", var.rds_instance_identifier,
             { stat = "Maximum", color = "#2ca02c", label = "Connections", yAxis = "right" }]
           ]
           view    = "timeSeries"
@@ -157,13 +157,13 @@ resource "aws_cloudwatch_dashboard" "main" {
         width  = 8
         height = 6
         properties = {
-          title  = "RDS Aurora — ACU & Storage"
+          title  = "RDS MySQL — Free Storage & Memory"
           region = var.aws_region
           metrics = [
-            ["AWS/RDS", "ServerlessDatabaseCapacity", "DBClusterIdentifier", var.rds_cluster_identifier,
-            { stat = "Average", color = "#1f77b4", label = "ACU" }],
-            ["AWS/RDS", "VolumeBytesUsed", "DBClusterIdentifier", var.rds_cluster_identifier,
-            { stat = "Average", color = "#2ca02c", label = "Storage (bytes)", yAxis = "right" }]
+            ["AWS/RDS", "FreeStorageSpace", "DBInstanceIdentifier", var.rds_instance_identifier,
+            { stat = "Minimum", color = "#2ca02c", label = "Free Storage (bytes)" }],
+            ["AWS/RDS", "FreeableMemory", "DBInstanceIdentifier", var.rds_instance_identifier,
+            { stat = "Average", color = "#1f77b4", label = "Freeable Memory (bytes)", yAxis = "right" }]
           ]
           view    = "timeSeries"
           stacked = false
@@ -188,7 +188,7 @@ resource "aws_cloudwatch_dashboard" "main" {
             aws_cloudwatch_metric_alarm.api_latency.arn,
             aws_cloudwatch_metric_alarm.rds_cpu.arn,
             aws_cloudwatch_metric_alarm.rds_connections.arn,
-            aws_cloudwatch_metric_alarm.rds_acu_utilization.arn,
+            aws_cloudwatch_metric_alarm.rds_free_storage.arn,
           ]
         }
       },

--- a/infra/modules/monitoring/main.tf
+++ b/infra/modules/monitoring/main.tf
@@ -168,12 +168,12 @@ resource "aws_cloudwatch_metric_alarm" "api_latency" {
 }
 
 # =============================================================================
-# CloudWatch Alarms — RDS Aurora
+# CloudWatch Alarms — RDS MySQL
 # =============================================================================
 
 resource "aws_cloudwatch_metric_alarm" "rds_cpu" {
   alarm_name          = "${var.name_prefix}-rds-cpu"
-  alarm_description   = "RDS Aurora CPU utilization exceeds threshold"
+  alarm_description   = "RDS MySQL CPU utilization exceeds threshold"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 3
   metric_name         = "CPUUtilization"
@@ -187,7 +187,7 @@ resource "aws_cloudwatch_metric_alarm" "rds_cpu" {
   ok_actions          = local.alarm_actions
 
   dimensions = {
-    DBClusterIdentifier = var.rds_cluster_identifier
+    DBInstanceIdentifier = var.rds_instance_identifier
   }
 
   tags = {
@@ -211,7 +211,7 @@ resource "aws_cloudwatch_metric_alarm" "rds_connections" {
   ok_actions          = local.alarm_actions
 
   dimensions = {
-    DBClusterIdentifier = var.rds_cluster_identifier
+    DBInstanceIdentifier = var.rds_instance_identifier
   }
 
   tags = {
@@ -219,27 +219,27 @@ resource "aws_cloudwatch_metric_alarm" "rds_connections" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "rds_acu_utilization" {
-  alarm_name          = "${var.name_prefix}-rds-acu"
-  alarm_description   = "RDS Aurora ACU utilization exceeds threshold"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = 3
-  metric_name         = "ServerlessDatabaseCapacity"
+resource "aws_cloudwatch_metric_alarm" "rds_free_storage" {
+  alarm_name          = "${var.name_prefix}-rds-free-storage"
+  alarm_description   = "RDS free storage space is critically low"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = 2
+  metric_name         = "FreeStorageSpace"
   namespace           = "AWS/RDS"
   period              = 300
-  statistic           = "Maximum"
-  threshold           = var.rds_acu_threshold
+  statistic           = "Minimum"
+  threshold           = var.rds_free_storage_threshold_bytes
   treat_missing_data  = "notBreaching"
   actions_enabled     = var.alarm_actions_enabled
   alarm_actions       = local.alarm_actions
   ok_actions          = local.alarm_actions
 
   dimensions = {
-    DBClusterIdentifier = var.rds_cluster_identifier
+    DBInstanceIdentifier = var.rds_instance_identifier
   }
 
   tags = {
-    Name = "${var.name_prefix}-rds-acu"
+    Name = "${var.name_prefix}-rds-free-storage"
   }
 }
 

--- a/infra/modules/monitoring/variables.tf
+++ b/infra/modules/monitoring/variables.tf
@@ -31,14 +31,9 @@ variable "api_gateway_stage" {
   default     = "$default"
 }
 
-# RDS Aurora
-variable "rds_cluster_identifier" {
-  description = "RDS Aurora cluster identifier"
-  type        = string
-}
-
+# RDS
 variable "rds_instance_identifier" {
-  description = "RDS Aurora instance identifier"
+  description = "RDS instance identifier"
   type        = string
 }
 
@@ -115,10 +110,10 @@ variable "rds_connections_threshold" {
   default     = 50
 }
 
-variable "rds_acu_threshold" {
-  description = "RDS ACU utilization threshold"
+variable "rds_free_storage_threshold_bytes" {
+  description = "RDS free storage space threshold in bytes (alarm when below)"
   type        = number
-  default     = 1.5
+  default     = 2147483648 # 2 GB
 }
 
 variable "api_gateway_log_group_name" {

--- a/infra/modules/rds/main.tf
+++ b/infra/modules/rds/main.tf
@@ -15,7 +15,7 @@ resource "aws_db_subnet_group" "main" {
 
 resource "aws_security_group" "rds" {
   name        = "${var.name_prefix}-rds-sg"
-  description = "Security group for Aurora Serverless v2"
+  description = "Security group for RDS MySQL"
   vpc_id      = var.vpc_id
 
   ingress {
@@ -31,23 +31,24 @@ resource "aws_security_group" "rds" {
   }
 }
 
-resource "aws_rds_cluster" "main" {
-  cluster_identifier = "${var.name_prefix}-aurora"
-  engine             = "aurora-mysql"
-  engine_mode        = "provisioned"
-  engine_version     = "8.0.mysql_aurora.3.07.1"
-  database_name      = "mindtrack"
-  master_username    = "mindtrack_admin"
+resource "aws_db_instance" "main" {
+  identifier        = "${var.name_prefix}-mysql"
+  engine            = "mysql"
+  engine_version    = "8.0"
+  instance_class    = "db.t3.micro"
+  allocated_storage = 20
+  storage_type      = "gp2"
+
+  db_name  = "mindtrack"
+  username = "mindtrack_admin"
 
   manage_master_user_password = true
 
   db_subnet_group_name   = aws_db_subnet_group.main.name
   vpc_security_group_ids = [aws_security_group.rds.id]
 
-  serverlessv2_scaling_configuration {
-    min_capacity = var.min_capacity
-    max_capacity = var.max_capacity
-  }
+  multi_az            = false
+  publicly_accessible = false
 
   skip_final_snapshot       = false
   final_snapshot_identifier = "${var.name_prefix}-final-snapshot"
@@ -58,20 +59,6 @@ resource "aws_rds_cluster" "main" {
   kms_key_id              = aws_kms_key.rds.arn
 
   tags = {
-    Name = "${var.name_prefix}-aurora"
-  }
-}
-
-resource "aws_rds_cluster_instance" "main" {
-  cluster_identifier = aws_rds_cluster.main.id
-  instance_class     = "db.serverless"
-  engine             = aws_rds_cluster.main.engine
-  engine_version     = aws_rds_cluster.main.engine_version
-
-  performance_insights_enabled    = true
-  performance_insights_kms_key_id = aws_kms_key.rds.arn
-
-  tags = {
-    Name = "${var.name_prefix}-aurora-instance"
+    Name = "${var.name_prefix}-mysql"
   }
 }

--- a/infra/modules/rds/outputs.tf
+++ b/infra/modules/rds/outputs.tf
@@ -1,21 +1,21 @@
 output "cluster_endpoint" {
-  description = "Aurora cluster endpoint"
-  value       = aws_rds_cluster.main.endpoint
+  description = "RDS instance endpoint"
+  value       = aws_db_instance.main.address
 }
 
 output "cluster_port" {
-  description = "Aurora cluster port"
-  value       = aws_rds_cluster.main.port
+  description = "RDS instance port"
+  value       = aws_db_instance.main.port
 }
 
 output "cluster_identifier" {
-  description = "Aurora cluster identifier"
-  value       = aws_rds_cluster.main.cluster_identifier
+  description = "RDS instance identifier"
+  value       = aws_db_instance.main.identifier
 }
 
 output "instance_identifier" {
-  description = "Aurora instance identifier"
-  value       = aws_rds_cluster_instance.main.identifier
+  description = "RDS instance identifier"
+  value       = aws_db_instance.main.identifier
 }
 
 output "security_group_id" {

--- a/infra/modules/rds/variables.tf
+++ b/infra/modules/rds/variables.tf
@@ -3,16 +3,6 @@ variable "name_prefix" {
   type        = string
 }
 
-variable "min_capacity" {
-  description = "Minimum ACU for Aurora Serverless v2"
-  type        = number
-}
-
-variable "max_capacity" {
-  description = "Maximum ACU for Aurora Serverless v2"
-  type        = number
-}
-
 variable "lambda_sg_id" {
   description = "Security group ID of the Lambda function"
   type        = string

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -9,18 +9,6 @@ variable "environment" {
   type        = string
 }
 
-variable "db_min_capacity" {
-  description = "Aurora Serverless v2 minimum ACU"
-  type        = number
-  default     = 0.5
-}
-
-variable "db_max_capacity" {
-  description = "Aurora Serverless v2 maximum ACU"
-  type        = number
-  default     = 2
-}
-
 variable "lambda_memory_size" {
   description = "Lambda function memory in MB"
   type        = number


### PR DESCRIPTION
Replace \`aws_rds_cluster\` + \`aws_rds_cluster_instance\` (Aurora Serverless v2, aurora-mysql) with \`aws_db_instance\` (standard MySQL 8.0, db.t3.micro) to stay within AWS free tier constraints.

Aurora MySQL is not available on the free tier — only \`aurora-postgresql\` is, which would require rewriting all Flyway migrations.

## Changes

- \`infra/modules/rds/main.tf\` — rewrite with \`aws_db_instance\`; KMS encryption retained; \`manage_master_user_password\`, deletion protection, and final snapshot preserved; \`backup_retention_period=1\` with \`#tfsec:ignore\` comment
- \`infra/modules/rds/variables.tf\` — remove \`min_capacity\` / \`max_capacity\`
- \`infra/modules/rds/outputs.tf\` — remap outputs to \`aws_db_instance\` attributes (same names, backward compatible)
- \`infra/modules/monitoring/main.tf\` — replace \`DBClusterIdentifier\` → \`DBInstanceIdentifier\`; replace Aurora ACU alarm with \`FreeStorageSpace\` alarm
- \`infra/modules/monitoring/variables.tf\` — remove \`rds_cluster_identifier\` and \`rds_acu_threshold\`; add \`rds_free_storage_threshold_bytes\` (default 2 GB)
- \`infra/modules/monitoring/dashboard-database.tf\` — rewrite for standard RDS MySQL metrics (no Aurora-only metrics)
- \`infra/modules/monitoring/dashboard-overview.tf\` — replace Aurora cluster widgets with RDS instance widgets
- \`infra/main.tf\` — remove \`min_capacity\`/\`max_capacity\` from RDS call; remove \`rds_cluster_identifier\` from monitoring call
- \`infra/variables.tf\` — remove \`db_min_capacity\` and \`db_max_capacity\`
- \`infra/environments/{dev,prod}.tfvars\` — remove ACU capacity values

Closes #190