### PR TITLE
fix(ci): enforce Sonar coverage scan inputs

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -16,16 +16,59 @@ on:
 permissions: {}
 
 jobs:
-  backend:
-    name: Backend Build & Test
+  changes:
+    name: Detect Changed Areas
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      app_changed: ${{ steps.detect.outputs.app_changed }}
+      infra_changed: ${{ steps.detect.outputs.infra_changed }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed files
+        id: detect
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" != "push" ]; then
+            echo "app_changed=true" >> "$GITHUB_OUTPUT"
+            echo "infra_changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          BEFORE_SHA="${{ github.event.before }}"
+          AFTER_SHA="${{ github.sha }}"
+
+          if [ -z "$BEFORE_SHA" ] || [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            BEFORE_SHA="$(git rev-parse "${AFTER_SHA}^" 2>/dev/null || echo "$AFTER_SHA")"
+          fi
+
+          CHANGED_FILES="$(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA")"
+          printf 'Changed files between %s and %s:\n%s\n' "$BEFORE_SHA" "$AFTER_SHA" "$CHANGED_FILES"
+
+          if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(backend/|frontend/|sonar-project\.properties$|\.github/workflows/(feature|verify)\.yml$)'; then
+            echo "app_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "app_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(infra/|\.github/workflows/feature\.yml$)'; then
+            echo "infra_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "infra_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  backend:
+    name: Backend Build & Test
+    runs-on: ubuntu-latest
+    needs: changes
+    permissions:
+      contents: read
       actions: write
-    if: >
-      github.event_name == 'pull_request' ||
-      contains(github.event.head_commit.modified, 'backend/') ||
-      contains(github.event.head_commit.added, 'backend/')
+    if: needs.changes.outputs.app_changed == 'true'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -55,13 +98,11 @@ jobs:
   frontend:
     name: Frontend Build & Test
     runs-on: ubuntu-latest
+    needs: changes
     permissions:
       contents: read
       actions: write
-    if: >
-      github.event_name == 'pull_request' ||
-      contains(github.event.head_commit.modified, 'frontend/') ||
-      contains(github.event.head_commit.added, 'frontend/')
+    if: needs.changes.outputs.app_changed == 'true'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -102,12 +143,10 @@ jobs:
   infra:
     name: Terraform Validate
     runs-on: ubuntu-latest
+    needs: changes
     permissions:
       contents: read
-    if: >
-      github.event_name == 'pull_request' ||
-      contains(github.event.head_commit.modified, 'infra/') ||
-      contains(github.event.head_commit.added, 'infra/')
+    if: needs.changes.outputs.infra_changed == 'true'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -159,8 +198,8 @@ jobs:
       actions: read
       pull-requests: write
       statuses: write
-    needs: [backend, frontend]
-    if: always() && (needs.backend.result == 'success' || needs.frontend.result == 'success')
+    needs: [changes, backend, frontend]
+    if: needs.changes.outputs.app_changed == 'true' && needs.backend.result == 'success' && needs.frontend.result == 'success'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -182,41 +221,18 @@ jobs:
 
       - name: Download frontend coverage
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.3.0
-        if: needs.frontend.result == 'success'
         with:
           name: frontend-coverage
           path: frontend/coverage/
 
+      - name: Verify Sonar inputs
+        run: |
+          test -f backend/target/site/jacoco/jacoco.xml
+          test -d backend/target/classes
+          test -f frontend/coverage/lcov.info
+
       - name: SonarCloud Scan
-        id: sonar
-        continue-on-error: true
         uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
-      - name: Check SonarCloud Quality Gate
-        if: always()
-        run: |
-          if [ "${{ steps.sonar.outcome }}" = "success" ]; then
-            echo "CI scan completed. Quality gate enforced by scanner."
-            exit 0
-          fi
-          PR_PARAM=""
-          if [ -n "${{ github.event.pull_request.number }}" ]; then
-            PR_PARAM="&pullRequest=${{ github.event.pull_request.number }}"
-          fi
-          STATUS=$(curl -s \
-            "https://sonarcloud.io/api/qualitygates/project_status?projectKey=lucasrudi_mindtrack${PR_PARAM}" \
-            | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('projectStatus',{}).get('status','UNKNOWN'))" 2>/dev/null || echo "UNKNOWN")
-          echo "SonarCloud quality gate: $STATUS"
-          if [ "$STATUS" = "ERROR" ]; then
-            echo "::error::SonarCloud quality gate FAILED"
-            exit 1
-          elif [ "$STATUS" = "OK" ] || [ "$STATUS" = "NONE" ]; then
-            echo "::notice::CI scan skipped (Automatic Analysis conflict). Quality gate OK."
-            exit 0
-          else
-            echo "::error::Quality gate status unknown: $STATUS"
-            exit 1
-          fi

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -137,51 +137,30 @@ jobs:
 
       - name: Download frontend coverage
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.3.0
-        continue-on-error: true
         with:
           name: frontend-coverage
           path: frontend/coverage/
 
       - name: Download backend coverage
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.3.0
-        continue-on-error: true
         with:
           name: backend-coverage
           path: backend/target/site/jacoco/
 
       - name: Download backend classes
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.3.0
-        continue-on-error: true
         with:
           name: backend-classes
           path: backend/target/classes/
 
+      - name: Verify Sonar inputs
+        run: |
+          test -f backend/target/site/jacoco/jacoco.xml
+          test -d backend/target/classes
+          test -f frontend/coverage/lcov.info
+
       - name: SonarCloud Scan
-        id: sonar
-        continue-on-error: true
         uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
-      - name: Check SonarCloud Quality Gate
-        if: always()
-        run: |
-          if [ "${{ steps.sonar.outcome }}" = "success" ]; then
-            echo "CI scan completed. Quality gate enforced by scanner."
-            exit 0
-          fi
-          STATUS=$(curl -s \
-            "https://sonarcloud.io/api/qualitygates/project_status?projectKey=lucasrudi_mindtrack" \
-            | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('projectStatus',{}).get('status','UNKNOWN'))" 2>/dev/null || echo "UNKNOWN")
-          echo "SonarCloud quality gate: $STATUS"
-          if [ "$STATUS" = "ERROR" ]; then
-            echo "::error::SonarCloud quality gate FAILED"
-            exit 1
-          elif [ "$STATUS" = "OK" ] || [ "$STATUS" = "NONE" ]; then
-            echo "::notice::CI scan skipped (Automatic Analysis conflict). Quality gate OK."
-            exit 0
-          else
-            echo "::error::Quality gate status unknown: $STATUS"
-            exit 1
-          fi

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -82,14 +82,15 @@ flowchart TD
 **Trigger:** Push to `feature/**`, `bugfix/**`, `chore/**`, or `renovate/**`; also on pull_request to `main`
 **Purpose:** Validate every code change before it can be merged.
 
-Runs backend build & test, frontend lint/test/build, and Terraform validation in parallel. The `sonar` job runs after either backend or frontend succeeds (OR condition — more lenient than `verify.yml`). Path filters skip jobs when their directory has no changes (on push; always runs on PR).
+Starts with a lightweight change-detection job. On feature-branch pushes, backend and frontend run together when application code or Sonar config changes so the Sonar job always has Java classes plus both coverage reports; infra runs only when infrastructure files change. On PRs and manual runs, all validation paths are enabled. The `sonar` job runs only after both backend and frontend succeed and fails immediately if coverage artifacts or the scan are missing.
 
 | Job | Steps |
 |-----|-------|
-| `backend` | Checkout → Java 21 → `mvn verify -B` → upload JaCoCo coverage |
+| `changes` | Checkout → diff pushed files → output `app_changed` / `infra_changed` flags |
+| `backend` | Checkout → Java 21 → `mvn verify -B` → upload JaCoCo coverage + classes |
 | `frontend` | Checkout → Node 20 → `npm ci` → lint → unit tests + coverage → build |
 | `infra` | Checkout → Terraform fmt/init/validate → tflint → tfsec (soft-fail) |
-| `sonar` | Download coverage artifacts → SonarCloud scan (continue-on-error) |
+| `sonar` | Download coverage artifacts → verify JaCoCo/LCOV inputs → SonarCloud scan |
 
 ---
 
@@ -98,14 +99,14 @@ Runs backend build & test, frontend lint/test/build, and Terraform validation in
 **Trigger:** Push to `main`
 **Purpose:** Full verification after every merge to main — no path filtering, all jobs always run.
 
-Identical steps to `feature.yml` but stricter: the `sonar` job requires **both** `backend-verify` AND `frontend-verify` to succeed (AND condition).
+Identical validation goals to `feature.yml`, but without change filtering: backend, frontend, and infra always run on `main`, and the `sonar` job requires both verify jobs to succeed. Coverage artifact downloads are strict and the job fails before scanning if JaCoCo XML, frontend LCOV, or backend classes are missing.
 
 | Job | Steps |
 |-----|-------|
-| `backend-verify` | Checkout → Java 21 → `mvn verify -B` → upload coverage |
+| `backend-verify` | Checkout → Java 21 → `mvn verify -B` → upload coverage + classes |
 | `frontend-verify` | Checkout → Node 20 → `npm ci` → lint → unit tests → build |
 | `infra-verify` | Checkout → Terraform fmt/init/validate → tflint → tfsec |
-| `sonar` | Download coverage → SonarCloud scan (requires both verify jobs to pass) |
+| `sonar` | Download coverage → verify JaCoCo/LCOV inputs → SonarCloud scan |
 
 ---
 

--- a/docs/sonar-quality-gates.md
+++ b/docs/sonar-quality-gates.md
@@ -4,6 +4,8 @@
 
 MindTrack uses [SonarCloud](https://sonarcloud.io/) for continuous code quality and security analysis. The quality gate is enforced in CI via `sonar.qualitygate.wait=true` in `sonar-project.properties` — any PR or push to `main` that fails the gate will fail the CI pipeline.
 
+Automatic Analysis must remain disabled for this project. MindTrack imports external JaCoCo and LCOV coverage reports from GitHub Actions, and the CI workflows are the only supported analysis path for coverage ingestion.
+
 ## Quality Gate Thresholds
 
 Configure these in the SonarCloud UI under **Quality Gates** for the `mindtrack` project:


### PR DESCRIPTION
## Summary
- remove the Sonar workflow fallback that treated skipped CI scans as success
- make feature branch change detection reliable and run backend/frontend together when app changes need Sonar inputs
- fail fast when JaCoCo XML, frontend LCOV, or backend classes are missing before the Sonar scan starts
- document that Automatic Analysis must stay disabled for coverage ingestion

## Testing
- git push -u origin HEAD:bugfix/195-fix-sonar-coverage-workflow

Closes #195
