### PR TITLE
docs(ci): clarify full PR validation behavior

### DIFF
--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -82,7 +82,7 @@ flowchart TD
 **Trigger:** Push to `feature/**`, `bugfix/**`, `chore/**`, or `renovate/**`; also on pull_request to `main`
 **Purpose:** Validate every code change before it can be merged.
 
-Starts with a lightweight change-detection job. On feature-branch pushes, backend and frontend run together when application code or Sonar config changes so the Sonar job always has Java classes plus both coverage reports; infra runs only when infrastructure files change. On PRs and manual runs, all validation paths are enabled. The `sonar` job runs only after both backend and frontend succeed and fails immediately if coverage artifacts or the scan are missing.
+Starts with a lightweight change-detection job. On feature-branch pushes, backend and frontend run together when application code or Sonar config changes so the Sonar job always has Java classes plus both coverage reports; infra runs only when infrastructure files change. On pull requests and manual runs, all validation paths are enabled regardless of the branch-push diff so the full merge gate is exercised before review. The `sonar` job runs only after both backend and frontend succeed and fails immediately if coverage artifacts or the scan are missing.
 
 | Job | Steps |
 |-----|-------|


### PR DESCRIPTION
## Summary
- add a small docs clarification that pull_request runs exercise the full validation gate regardless of branch-push diff
- use this PR to trigger backend, frontend, infra, and Sonar coverage validation together

## Testing
- git push -u origin HEAD:chore/198-trigger-pr-validation

Closes #198
