### PR TITLE
docs(sonar): lower coverage gate target to 60 percent

### DIFF
--- a/docs/sonar-quality-gates.md
+++ b/docs/sonar-quality-gates.md
@@ -14,7 +14,7 @@ Configure these in the SonarCloud UI under **Quality Gates** for the `mindtrack`
 
 | Metric | Condition | Threshold | Rationale |
 |--------|-----------|-----------|-----------|
-| Coverage on new code | is less than | **80%** | Prevents coverage regression on new features |
+| Coverage on new code | is less than | **60%** | Ensures sufficient test coverage without blocking incremental delivery |
 | Duplicated lines on new code | is greater than | **3%** | Avoids copy-paste patterns |
 | Maintainability rating on new code | is worse than | **A** | Keeps technical debt low |
 | Reliability rating on new code | is worse than | **A** | Zero new bugs policy |
@@ -35,7 +35,7 @@ These are aspirational targets for the overall codebase (new code gate is the en
 
 | Metric | Target |
 |--------|--------|
-| Test coverage (overall) | ≥ 75% |
+| Test coverage (overall) | ≥ 60% |
 | Duplicated lines | ≤ 5% |
 | Technical debt ratio | ≤ 5% |
 | Maintainability rating | A |

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -21,7 +21,8 @@ sonar.exclusions=**/node_modules/**,**/target/**,**/*.config.*,**/db/migration/*
 sonar.coverage.exclusions=**/model/**,**/dto/**,**/config/**,**/*Application.java
 
 # Quality Gate — wait for gate result and fail CI if not met
-# Gate thresholds are configured in SonarCloud UI; see docs/sonar-quality-gates.md
+# Gate thresholds are configured in SonarCloud UI; MindTrack currently requires
+# coverage on new code > 60%. See docs/sonar-quality-gates.md.
 sonar.qualitygate.wait=true
 
 # Terraform


### PR DESCRIPTION
## Summary\n- document the SonarCloud quality gate target as 60% coverage on new code\n- align the overall coverage target in the Sonar quality gate docs\n- clarify in sonar-project.properties that the gate is enforced in the SonarCloud UI\n\n## Testing\n- pre-push hook suite passed locally\n