### PR TITLE
ci(sonar): sync custom quality gate

### DIFF
--- a/.github/workflows/sonar-quality-gate-sync.yml
+++ b/.github/workflows/sonar-quality-gate-sync.yml
@@ -1,0 +1,128 @@
+name: Sonar Quality Gate Sync
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'sonar-project.properties'
+      - 'docs/sonar-quality-gates.md'
+      - '.github/workflows/sonar-quality-gate-sync.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    name: Sync SonarCloud Quality Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure Sonar token is configured
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          if [[ -z "$SONAR_TOKEN" ]]; then
+            echo "SONAR_TOKEN is required to manage SonarCloud quality gates." >&2
+            exit 1
+          fi
+
+      - name: Sync project quality gate
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io
+          SONAR_ORGANIZATION: lucasrudi
+          SONAR_PROJECT_KEY: lucasrudi_mindtrack
+          SONAR_GATE_NAME: MindTrack Gate
+          SONAR_NEW_COVERAGE_THRESHOLD: "60"
+        run: |
+          set -euo pipefail
+
+          api_get() {
+            curl --fail --silent --show-error \
+              -u "${SONAR_TOKEN}:" \
+              "$SONAR_HOST_URL$1"
+          }
+
+          api_post() {
+            local endpoint="$1"
+            shift
+            curl --fail --silent --show-error \
+              -u "${SONAR_TOKEN}:" \
+              -X POST \
+              "$SONAR_HOST_URL$endpoint" \
+              "$@"
+          }
+
+          list_gates() {
+            api_get "/api/qualitygates/list?organization=$SONAR_ORGANIZATION"
+          }
+
+          gate_id_from_list() {
+            jq -r --arg name "$1" '.qualitygates[] | select(.name == $name) | .id'
+          }
+
+          gate_list_json="$(list_gates)"
+          gate_id="$(printf '%s' "$gate_list_json" | gate_id_from_list "$SONAR_GATE_NAME" | head -n 1)"
+
+          if [[ -z "$gate_id" ]]; then
+            sonar_way_id="$(printf '%s' "$gate_list_json" | gate_id_from_list "Sonar way" | head -n 1)"
+            if [[ -z "$sonar_way_id" ]]; then
+              echo "Unable to locate the built-in Sonar way quality gate." >&2
+              exit 1
+            fi
+
+            api_post "/api/qualitygates/copy" \
+              --data-urlencode "organization=$SONAR_ORGANIZATION" \
+              --data-urlencode "id=$sonar_way_id" \
+              --data-urlencode "name=$SONAR_GATE_NAME" \
+              >/dev/null
+
+            gate_list_json="$(list_gates)"
+            gate_id="$(printf '%s' "$gate_list_json" | gate_id_from_list "$SONAR_GATE_NAME" | head -n 1)"
+          fi
+
+          if [[ -z "$gate_id" ]]; then
+            echo "Unable to create or locate quality gate '$SONAR_GATE_NAME'." >&2
+            exit 1
+          fi
+
+          gate_json="$(api_get "/api/qualitygates/show?organization=$SONAR_ORGANIZATION&id=$gate_id")"
+          coverage_condition_id="$(
+            printf '%s' "$gate_json" \
+              | jq -r '.conditions[] | select(.metric == "new_coverage") | .id'
+          )"
+
+          if [[ -z "$coverage_condition_id" ]]; then
+            api_post "/api/qualitygates/create_condition" \
+              --data-urlencode "organization=$SONAR_ORGANIZATION" \
+              --data-urlencode "gateId=$gate_id" \
+              --data-urlencode "metric=new_coverage" \
+              --data-urlencode "op=LT" \
+              --data-urlencode "error=$SONAR_NEW_COVERAGE_THRESHOLD" \
+              >/dev/null
+          else
+            api_post "/api/qualitygates/update_condition" \
+              --data-urlencode "organization=$SONAR_ORGANIZATION" \
+              --data-urlencode "id=$coverage_condition_id" \
+              --data-urlencode "metric=new_coverage" \
+              --data-urlencode "op=LT" \
+              --data-urlencode "error=$SONAR_NEW_COVERAGE_THRESHOLD" \
+              >/dev/null
+          fi
+
+          api_post "/api/qualitygates/select" \
+            --data-urlencode "organization=$SONAR_ORGANIZATION" \
+            --data-urlencode "gateId=$gate_id" \
+            --data-urlencode "projectKey=$SONAR_PROJECT_KEY" \
+            >/dev/null
+
+          current_gate="$(api_get "/api/qualitygates/get_by_project?organization=$SONAR_ORGANIZATION&project=$SONAR_PROJECT_KEY")"
+          current_gate_name="$(printf '%s' "$current_gate" | jq -r '.qualityGate.name')"
+          current_gate_id="$(printf '%s' "$current_gate" | jq -r '.qualityGate.id')"
+
+          echo "Project quality gate is now '$current_gate_name' (id=$current_gate_id)."
+
+          if [[ "$current_gate_name" != "$SONAR_GATE_NAME" ]]; then
+            echo "Quality gate association did not switch to '$SONAR_GATE_NAME'." >&2
+            exit 1
+          fi

--- a/docs/sonar-quality-gates.md
+++ b/docs/sonar-quality-gates.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-MindTrack uses [SonarCloud](https://sonarcloud.io/) for continuous code quality and security analysis. The quality gate is enforced in CI via `sonar.qualitygate.wait=true` in `sonar-project.properties` — any PR or push to `main` that fails the gate will fail the CI pipeline.
+MindTrack uses [SonarCloud](https://sonarcloud.io/) for continuous code quality and security analysis. The quality gate result is enforced in CI via `sonar.qualitygate.wait=true` in `sonar-project.properties`, but the gate itself is owned by SonarCloud project settings, not by the properties file.
 
 Automatic Analysis must remain disabled for this project. MindTrack imports external JaCoCo and LCOV coverage reports from GitHub Actions, and the CI workflows are the only supported analysis path for coverage ingestion.
 
@@ -10,9 +10,11 @@ Automatic Analysis must remain disabled for this project. MindTrack imports exte
 If the SonarCloud project is private and CI waits for the quality gate result, the token in GitHub Actions must belong to a user who can both submit analysis and browse the project. A Scoped Organization Token is not sufficient for this flow because it only grants Execute Analysis. In practice, `SONAR_TOKEN` should be a Personal Access Token from a SonarCloud user with both **Execute Analysis** and **Browse** access to `lucasrudi_mindtrack`.
 
 After rotating `SONAR_TOKEN`, trigger a fresh PR analysis by opening a new pull request or pushing a new commit to an existing PR branch. That forces SonarCloud to rebuild the PR issue review state with the updated token permissions.
+
+The repository also includes `.github/workflows/sonar-quality-gate-sync.yml`, which creates or updates the custom `MindTrack Gate`, sets `Coverage on new code` to `60`, and re-associates the `lucasrudi_mindtrack` project with that gate. For this workflow to succeed, `SONAR_TOKEN` must belong to a SonarCloud user who can administer quality gates for the project.
 ## Quality Gate Thresholds
 
-Configure these in the SonarCloud UI under **Quality Gates** for the `mindtrack` project:
+These are the target conditions for the custom `MindTrack Gate`. The sync workflow enforces the `Coverage on new code` threshold automatically; the other conditions should still be present on the custom gate in SonarCloud:
 
 | Metric | Condition | Threshold | Rationale |
 |--------|-----------|-----------|-----------|
@@ -26,10 +28,10 @@ Configure these in the SonarCloud UI under **Quality Gates** for the `mindtrack`
 ## How to Configure in SonarCloud
 
 1. Go to [sonarcloud.io](https://sonarcloud.io/) → your organization → **Quality Gates**
-2. Create a new gate named `MindTrack Gate` (or edit the existing default)
-3. Add each condition from the table above
-4. Navigate to the **mindtrack** project → **Project Settings** → **Quality Gate**
-5. Select `MindTrack Gate`
+2. Create a new gate named `MindTrack Gate` by copying `Sonar way` if it does not already exist
+3. Ensure each condition from the table above is present
+4. Run the `Sonar Quality Gate Sync` workflow or navigate to the **mindtrack** project → **Project Settings** → **Quality Gate**
+5. Confirm the project is associated with `MindTrack Gate`
 
 ## Overall Code Quality Targets
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -21,8 +21,9 @@ sonar.exclusions=**/node_modules/**,**/target/**,**/*.config.*,**/db/migration/*
 sonar.coverage.exclusions=**/model/**,**/dto/**,**/config/**,**/*Application.java
 
 # Quality Gate — wait for gate result and fail CI if not met
-# Gate thresholds are configured in SonarCloud UI; MindTrack currently requires
-# coverage on new code > 60%. See docs/sonar-quality-gates.md.
+# Gate thresholds are configured in SonarCloud project settings, not in this file.
+# The Sonar Quality Gate Sync workflow keeps the project associated with the
+# custom "MindTrack Gate" that requires coverage on new code > 60%.
 sonar.qualitygate.wait=true
 
 # Terraform


### PR DESCRIPTION
## Summary
- add a SonarCloud quality-gate sync workflow that creates or updates `MindTrack Gate`
- pin the project to the custom gate with `new_coverage < 60` treated as an error
- clarify in repo docs and `sonar-project.properties` that the gate is enforced in SonarCloud, not by scanner properties

Closes #210