### PR TITLE
fix(infra): ignore deploy-managed lambda sentry dsn

### DIFF
--- a/infra/modules/lambda/main.tf
+++ b/infra/modules/lambda/main.tf
@@ -61,6 +61,14 @@ resource "aws_lambda_function" "api" {
   tags = {
     Name = "${var.name_prefix}-api"
   }
+
+  lifecycle {
+    # SENTRY_DSN is injected by the release workflow after reading from Secrets Manager.
+    # Terraform should not try to remove that deploy-managed variable during infra applies.
+    ignore_changes = [
+      environment[0].variables["SENTRY_DSN"],
+    ]
+  }
 }
 
 # Create a placeholder zip for initial deployment


### PR DESCRIPTION
## Summary
- ignore the deploy-managed `SENTRY_DSN` environment variable on the Lambda Terraform resource
- prevent infra applies from trying to remove that release-managed value
- avoid the AWS provider inconsistent final plan error triggered by the unnecessary Lambda update

Closes #217