### PR TITLE
test(coverage): improve sonar coverage hotspots

### DIFF
--- a/backend/src/test/java/com/mindtrack/ai/service/ContextBuilderTest.java
+++ b/backend/src/test/java/com/mindtrack/ai/service/ContextBuilderTest.java
@@ -1,13 +1,28 @@
 package com.mindtrack.ai.service;
 
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
 @ActiveProfiles("local")
@@ -40,5 +55,225 @@ class ContextBuilderTest {
         String prompt = contextBuilder.buildSystemPrompt(999L);
         assertNotNull(prompt);
         assertTrue(prompt.contains("supportive AI mental health coach"));
+    }
+
+    /**
+     * Unit-level tests using a mocked JdbcTemplate to exercise populated and empty query paths
+     * without a running database.
+     */
+    @Nested
+    @ExtendWith(MockitoExtension.class)
+    class WithMockedJdbc {
+
+        @Mock
+        private JdbcTemplate jdbcTemplate;
+
+        @InjectMocks
+        private ContextBuilder contextBuilder;
+
+        // -----------------------------------------------------------------------
+        // buildSystemPrompt — populated paths
+        // -----------------------------------------------------------------------
+
+        @Test
+        void shouldIncludeMoodContextWhenJournalEntriesExist() {
+            // appendMoodContext calls: queryForList(sql, userId, MOOD_HISTORY_DAYS)
+            // Use lenient to avoid UnnecessaryStubbing for other queryForList calls
+            org.mockito.Mockito.lenient()
+                    .when(jdbcTemplate.queryForList(anyString(), any(Object[].class)))
+                    .thenReturn(List.of());
+            when(jdbcTemplate.queryForList(
+                    org.mockito.ArgumentMatchers.contains("journal_entries"),
+                    any(Object[].class)))
+                    .thenReturn(List.of(
+                            Map.of("entry_date", "2025-01-10", "mood", 7),
+                            Map.of("entry_date", "2025-01-09", "mood", 5)
+                    ));
+
+            String prompt = contextBuilder.buildSystemPrompt(1L);
+
+            assertNotNull(prompt);
+            assertTrue(prompt.contains("RECENT MOOD DATA"));
+        }
+
+        @Test
+        void shouldIncludeGoalContextWhenActiveGoalsExist() {
+            // appendGoalContext calls: queryForList(sql, userId) where sql contains "goals g LEFT JOIN"
+            org.mockito.Mockito.lenient()
+                    .when(jdbcTemplate.queryForList(anyString(), any(Object[].class)))
+                    .thenReturn(List.of());
+            when(jdbcTemplate.queryForList(
+                    org.mockito.ArgumentMatchers.contains("goals g LEFT JOIN milestones"),
+                    any(Object[].class)))
+                    .thenReturn(List.of(
+                            Map.of("title", "Run a 5K",
+                                    "status", "IN_PROGRESS",
+                                    "total_milestones", 3L,
+                                    "completed_milestones", 1L)
+                    ));
+
+            String prompt = contextBuilder.buildSystemPrompt(1L);
+
+            assertNotNull(prompt);
+            assertTrue(prompt.contains("ACTIVE GOALS"));
+            assertTrue(prompt.contains("Run a 5K"));
+        }
+
+        @Test
+        void shouldIncludeInterviewContextWhenRecentInterviewExists() {
+            // appendInterviewContext calls: queryForList(sql, userId, INTERVIEW_RECENCY_DAYS)
+            org.mockito.Mockito.lenient()
+                    .when(jdbcTemplate.queryForList(anyString(), any(Object[].class)))
+                    .thenReturn(List.of());
+            when(jdbcTemplate.queryForList(
+                    org.mockito.ArgumentMatchers.contains("FROM interviews"),
+                    any(Object[].class)))
+                    .thenReturn(List.of(
+                            Map.of("interview_date", "2025-01-05",
+                                    "recommendations", "Practice deep breathing",
+                                    "mood_after", 8)
+                    ));
+
+            String prompt = contextBuilder.buildSystemPrompt(1L);
+
+            assertNotNull(prompt);
+            assertTrue(prompt.contains("LATEST INTERVIEW"));
+            assertTrue(prompt.contains("Practice deep breathing"));
+        }
+
+        @Test
+        void shouldIncludeActivityContextWhenActivitiesExist() {
+            // appendActivityContext calls: queryForList(sql, MOOD_HISTORY_DAYS, userId)
+            org.mockito.Mockito.lenient()
+                    .when(jdbcTemplate.queryForList(anyString(), any(Object[].class)))
+                    .thenReturn(List.of());
+            when(jdbcTemplate.queryForList(
+                    org.mockito.ArgumentMatchers.contains("activities a LEFT JOIN activity_logs"),
+                    any(Object[].class)))
+                    .thenReturn(List.of(
+                            Map.of("name", "Morning run", "completed_count", 5L)
+                    ));
+
+            String prompt = contextBuilder.buildSystemPrompt(1L);
+
+            assertNotNull(prompt);
+            assertTrue(prompt.contains("ACTIVE ACTIVITIES"));
+            assertTrue(prompt.contains("Morning run"));
+        }
+
+        // -----------------------------------------------------------------------
+        // buildSystemPrompt — empty/fallback paths
+        // -----------------------------------------------------------------------
+
+        @Test
+        void shouldReturnValidPromptWhenAllRepositoriesReturnEmpty() {
+            // All list queries return empty — no context sections should be appended
+            when(jdbcTemplate.queryForList(anyString(), any(Object[].class)))
+                    .thenReturn(List.of());
+
+            String prompt = contextBuilder.buildSystemPrompt(1L);
+
+            assertNotNull(prompt);
+            assertFalse(prompt.isBlank());
+            assertTrue(prompt.contains("supportive AI mental health coach"));
+            assertFalse(prompt.contains("RECENT MOOD DATA"));
+            assertFalse(prompt.contains("ACTIVE GOALS"));
+            assertFalse(prompt.contains("LATEST INTERVIEW"));
+        }
+
+        // -----------------------------------------------------------------------
+        // generateFingerprint
+        // -----------------------------------------------------------------------
+
+        @Test
+        void shouldReturnValidFingerprintWhenAllQueriesThrowOrReturnEmpty() {
+            // queryLatestMood throws (no journal entries)
+            when(jdbcTemplate.queryForObject(
+                    org.mockito.ArgumentMatchers.contains("journal_entries"),
+                    eq(Integer.class), any(Object[].class)))
+                    .thenThrow(new EmptyResultDataAccessException(1));
+            // queryActiveGoalsCount returns 0
+            when(jdbcTemplate.queryForObject(
+                    org.mockito.ArgumentMatchers.contains("FROM goals"),
+                    eq(Integer.class), any(Object[].class)))
+                    .thenReturn(0);
+            // queryRecentCompletions returns 0
+            when(jdbcTemplate.queryForObject(
+                    org.mockito.ArgumentMatchers.contains("activity_logs"),
+                    eq(Integer.class), any(Object[].class)))
+                    .thenReturn(0);
+            // queryLatestInterviewDate returns null
+            when(jdbcTemplate.queryForObject(
+                    org.mockito.ArgumentMatchers.contains("MAX(interview_date)"),
+                    eq(String.class), any(Object[].class)))
+                    .thenReturn(null);
+
+            String fingerprint = contextBuilder.generateFingerprint(1L);
+
+            assertNotNull(fingerprint);
+            assertFalse(fingerprint.isBlank());
+            // SHA-256 hex = 64 chars
+            assertEquals(64, fingerprint.length());
+        }
+
+        @Test
+        void shouldProduceDifferentFingerprintsWhenMoodChanges() {
+            // First call: mood = 7
+            when(jdbcTemplate.queryForObject(
+                    org.mockito.ArgumentMatchers.contains("journal_entries"),
+                    eq(Integer.class), any(Object[].class)))
+                    .thenReturn(7);
+            when(jdbcTemplate.queryForObject(
+                    org.mockito.ArgumentMatchers.contains("FROM goals"),
+                    eq(Integer.class), any(Object[].class)))
+                    .thenReturn(2);
+            when(jdbcTemplate.queryForObject(
+                    org.mockito.ArgumentMatchers.contains("activity_logs"),
+                    eq(Integer.class), any(Object[].class)))
+                    .thenReturn(5);
+            when(jdbcTemplate.queryForObject(
+                    org.mockito.ArgumentMatchers.contains("MAX(interview_date)"),
+                    eq(String.class), any(Object[].class)))
+                    .thenReturn("2025-01-10");
+
+            String fp1 = contextBuilder.generateFingerprint(1L);
+
+            // Second call: mood changed to 3
+            when(jdbcTemplate.queryForObject(
+                    org.mockito.ArgumentMatchers.contains("journal_entries"),
+                    eq(Integer.class), any(Object[].class)))
+                    .thenReturn(3);
+
+            String fp2 = contextBuilder.generateFingerprint(1L);
+
+            assertNotNull(fp1);
+            assertNotNull(fp2);
+            assertFalse(fp1.equals(fp2), "Fingerprints should differ when mood changes");
+        }
+
+        @Test
+        void shouldProduceSameFingerprintWhenDataUnchanged() {
+            when(jdbcTemplate.queryForObject(
+                    org.mockito.ArgumentMatchers.contains("journal_entries"),
+                    eq(Integer.class), any(Object[].class)))
+                    .thenReturn(6);
+            when(jdbcTemplate.queryForObject(
+                    org.mockito.ArgumentMatchers.contains("FROM goals"),
+                    eq(Integer.class), any(Object[].class)))
+                    .thenReturn(1);
+            when(jdbcTemplate.queryForObject(
+                    org.mockito.ArgumentMatchers.contains("activity_logs"),
+                    eq(Integer.class), any(Object[].class)))
+                    .thenReturn(3);
+            when(jdbcTemplate.queryForObject(
+                    org.mockito.ArgumentMatchers.contains("MAX(interview_date)"),
+                    eq(String.class), any(Object[].class)))
+                    .thenReturn("2025-02-01");
+
+            String fp1 = contextBuilder.generateFingerprint(1L);
+            String fp2 = contextBuilder.generateFingerprint(1L);
+
+            assertEquals(fp1, fp2, "Fingerprints should be identical when data is unchanged");
+        }
     }
 }

--- a/backend/src/test/java/com/mindtrack/ai/service/ConversationServiceTest.java
+++ b/backend/src/test/java/com/mindtrack/ai/service/ConversationServiceTest.java
@@ -2,24 +2,32 @@ package com.mindtrack.ai.service;
 
 import com.mindtrack.ai.dto.ChatRequest;
 import com.mindtrack.ai.dto.ChatResponse;
+import com.mindtrack.ai.dto.ConversationDto;
+import com.mindtrack.ai.model.Channel;
+import com.mindtrack.ai.model.Conversation;
 import com.mindtrack.ai.model.ConversationType;
 import com.mindtrack.ai.repository.ConversationRepository;
 import com.mindtrack.ai.repository.MessageRepository;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -123,5 +131,183 @@ class ConversationServiceTest {
 
         // Assert — cache.put is called but AiResponseCache.isCacheable returns false for COACHING
         verify(responseCache).put(eq(1L), eq(ConversationType.COACHING), eq("test-fp"), any());
+    }
+
+    @Test
+    void shouldReturnExistingConversation() {
+        // Arrange
+        Conversation conversation = new Conversation(1L, Channel.WEB);
+        conversation.setId(42L);
+
+        when(conversationRepository.findByIdAndUserId(42L, 1L))
+                .thenReturn(Optional.of(conversation));
+        when(messageRepository.findByConversationIdOrderByCreatedAtAsc(42L))
+                .thenReturn(List.of());
+
+        // Act
+        ConversationDto dto = conversationService.getConversation(42L, 1L);
+
+        // Assert
+        assertNotNull(dto);
+        assertEquals(42L, dto.id());
+        assertEquals(Channel.WEB, dto.channel());
+    }
+
+    @Test
+    void shouldThrowNotFoundWhenConversationDoesNotExist() {
+        // Arrange
+        when(conversationRepository.findByIdAndUserId(999L, 1L))
+                .thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(ResponseStatusException.class,
+                () -> conversationService.getConversation(999L, 1L));
+    }
+
+    @Test
+    void shouldThrowNotFoundWhenConversationBelongsToAnotherUser() {
+        // Arrange — user 2 owns the conversation, user 1 tries to access it
+        when(conversationRepository.findByIdAndUserId(10L, 1L))
+                .thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(ResponseStatusException.class,
+                () -> conversationService.getConversation(10L, 1L));
+    }
+
+    @Test
+    void shouldReuseExistingConversationOnSecondChatMessage() {
+        // Arrange — first call creates conversation (id=1), second call reuses it via conversationId
+        ChatRequest first = new ChatRequest(null, "First message", ConversationType.COACHING);
+        ChatRequest second = new ChatRequest(1L, "Second message", ConversationType.COACHING);
+        ChatResponse apiResponse = new ChatResponse(null, null, "Response.", false, 100);
+
+        when(contextBuilder.generateFingerprint(1L)).thenReturn("fp");
+        when(responseCache.get(anyLong(), any(), anyString())).thenReturn(null);
+        when(contextBuilder.buildSystemPrompt(anyLong())).thenReturn("prompt");
+
+        Conversation conversation = new Conversation(1L, Channel.WEB);
+        conversation.setId(1L);
+
+        // First call: no existing conversation → save creates one
+        when(conversationRepository.save(any())).thenReturn(conversation);
+        when(messageRepository.save(any())).thenAnswer(inv -> {
+            var msg = inv.getArgument(0, com.mindtrack.ai.model.Message.class);
+            msg.setId(10L);
+            return msg;
+        });
+        when(messageRepository.findByConversationIdOrderByCreatedAtAsc(anyLong()))
+                .thenReturn(List.of());
+        when(claudeApiClient.sendMessage(anyString(), any(), any())).thenReturn(apiResponse);
+
+        conversationService.chat(1L, first);
+
+        // Second call: conversationId=1 supplied → findById returns the existing conversation
+        when(conversationRepository.findById(1L)).thenReturn(Optional.of(conversation));
+
+        conversationService.chat(1L, second);
+
+        // Assert — save was called once for the first conversation creation; not again for second
+        verify(conversationRepository, times(1)).save(any(Conversation.class));
+    }
+
+    @Test
+    void shouldChatWithTelegramChannel() {
+        // Arrange
+        ChatRequest request = new ChatRequest(null, "Hello from Telegram", ConversationType.COACHING);
+        ChatResponse apiResponse = new ChatResponse(null, null, "Hi there!", false, 80);
+
+        when(contextBuilder.generateFingerprint(1L)).thenReturn("fp");
+        when(responseCache.get(anyLong(), any(), anyString())).thenReturn(null);
+        when(contextBuilder.buildSystemPrompt(anyLong())).thenReturn("prompt");
+        when(conversationRepository.findByUserIdAndChannelOrderByStartedAtDesc(1L, Channel.TELEGRAM))
+                .thenReturn(List.of());
+        when(conversationRepository.save(any())).thenAnswer(inv -> {
+            var conv = inv.getArgument(0, Conversation.class);
+            conv.setId(5L);
+            return conv;
+        });
+        when(messageRepository.save(any())).thenAnswer(inv -> {
+            var msg = inv.getArgument(0, com.mindtrack.ai.model.Message.class);
+            msg.setId(20L);
+            return msg;
+        });
+        when(messageRepository.findByConversationIdOrderByCreatedAtAsc(anyLong()))
+                .thenReturn(List.of());
+        when(claudeApiClient.sendMessage(anyString(), any(), eq(ConversationType.COACHING)))
+                .thenReturn(apiResponse);
+
+        // Act
+        ChatResponse result = conversationService.chatWithChannel(1L, request, Channel.TELEGRAM);
+
+        // Assert
+        assertFalse(result.cached());
+        assertEquals("Hi there!", result.content());
+        verify(conversationRepository).findByUserIdAndChannelOrderByStartedAtDesc(1L, Channel.TELEGRAM);
+    }
+
+    @Test
+    void shouldChatWithWhatsAppChannel() {
+        // Arrange
+        ChatRequest request = new ChatRequest(null, "Hello from WhatsApp", ConversationType.QUICK_CHECKIN);
+        ChatResponse apiResponse = new ChatResponse(null, null, "How are you?", false, 60);
+
+        when(contextBuilder.generateFingerprint(1L)).thenReturn("fp-wa");
+        when(responseCache.get(anyLong(), any(), anyString())).thenReturn(null);
+        when(contextBuilder.buildSystemPrompt(anyLong())).thenReturn("prompt");
+        when(conversationRepository.findByUserIdAndChannelOrderByStartedAtDesc(1L, Channel.WHATSAPP))
+                .thenReturn(List.of());
+        when(conversationRepository.save(any())).thenAnswer(inv -> {
+            var conv = inv.getArgument(0, Conversation.class);
+            conv.setId(6L);
+            return conv;
+        });
+        when(messageRepository.save(any())).thenAnswer(inv -> {
+            var msg = inv.getArgument(0, com.mindtrack.ai.model.Message.class);
+            msg.setId(21L);
+            return msg;
+        });
+        when(messageRepository.findByConversationIdOrderByCreatedAtAsc(anyLong()))
+                .thenReturn(List.of());
+        when(claudeApiClient.sendMessage(anyString(), any(), eq(ConversationType.QUICK_CHECKIN)))
+                .thenReturn(apiResponse);
+
+        // Act
+        ChatResponse result = conversationService.chatWithChannel(1L, request, Channel.WHATSAPP);
+
+        // Assert
+        assertFalse(result.cached());
+        assertEquals("How are you?", result.content());
+        verify(conversationRepository).findByUserIdAndChannelOrderByStartedAtDesc(1L, Channel.WHATSAPP);
+    }
+
+    @Test
+    void shouldReuseExistingChannelConversation() {
+        // Arrange — an existing Telegram conversation already exists for user 1
+        Conversation existing = new Conversation(1L, Channel.TELEGRAM);
+        existing.setId(7L);
+
+        ChatRequest request = new ChatRequest(null, "Another message", ConversationType.COACHING);
+        ChatResponse apiResponse = new ChatResponse(null, null, "Sure!", false, 50);
+
+        when(contextBuilder.generateFingerprint(1L)).thenReturn("fp");
+        when(responseCache.get(anyLong(), any(), anyString())).thenReturn(null);
+        when(contextBuilder.buildSystemPrompt(anyLong())).thenReturn("prompt");
+        when(conversationRepository.findByUserIdAndChannelOrderByStartedAtDesc(1L, Channel.TELEGRAM))
+                .thenReturn(List.of(existing));
+        when(messageRepository.save(any())).thenAnswer(inv -> {
+            var msg = inv.getArgument(0, com.mindtrack.ai.model.Message.class);
+            msg.setId(30L);
+            return msg;
+        });
+        when(messageRepository.findByConversationIdOrderByCreatedAtAsc(anyLong()))
+                .thenReturn(List.of());
+        when(claudeApiClient.sendMessage(anyString(), any(), any())).thenReturn(apiResponse);
+
+        // Act
+        conversationService.chatWithChannel(1L, request, Channel.TELEGRAM);
+
+        // Assert — no new conversation was created; repository.save(Conversation) never called
+        verify(conversationRepository, never()).save(any(Conversation.class));
     }
 }

--- a/backend/src/test/java/com/mindtrack/messaging/controller/WhatsAppWebhookControllerTest.java
+++ b/backend/src/test/java/com/mindtrack/messaging/controller/WhatsAppWebhookControllerTest.java
@@ -3,6 +3,7 @@ package com.mindtrack.messaging.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mindtrack.messaging.dto.WhatsAppWebhook;
 import com.mindtrack.messaging.service.MessagingService;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
@@ -13,6 +14,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -85,5 +87,99 @@ class WhatsAppWebhookControllerTest {
                         .param("hub.verify_token", "test-verify-token")
                         .param("hub.challenge", "challenge-12345"))
                 .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void shouldReturnBadRequestForInvalidJsonBody() throws Exception {
+        // appSecret is blank so signature check is skipped; malformed JSON hits parse catch
+        mockMvc.perform(post("/api/webhooks/whatsapp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{this is not valid json}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenObjectFieldIsNotWhatsApp() throws Exception {
+        WhatsAppWebhook.Change change = new WhatsAppWebhook.Change();
+        change.setField("messages");
+
+        WhatsAppWebhook.Entry entry = new WhatsAppWebhook.Entry();
+        entry.setId("123");
+        entry.setChanges(List.of(change));
+
+        WhatsAppWebhook webhook = new WhatsAppWebhook();
+        webhook.setObject("instagram");   // wrong type — not "whatsapp_business_account"
+        webhook.setEntry(List.of(entry));
+
+        mockMvc.perform(post("/api/webhooks/whatsapp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(webhook)))
+                .andExpect(status().isBadRequest());
+
+        verify(messagingService, never()).handleWhatsAppMessage(any());
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenEntryIsEmpty() throws Exception {
+        WhatsAppWebhook webhook = new WhatsAppWebhook();
+        webhook.setObject("whatsapp_business_account");
+        webhook.setEntry(List.of());   // empty entry array
+
+        mockMvc.perform(post("/api/webhooks/whatsapp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(webhook)))
+                .andExpect(status().isBadRequest());
+
+        verify(messagingService, never()).handleWhatsAppMessage(any());
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenEntryIsNull() throws Exception {
+        // Explicitly construct JSON with null entry
+        String body = "{\"object\":\"whatsapp_business_account\",\"entry\":null}";
+
+        mockMvc.perform(post("/api/webhooks/whatsapp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+
+        verify(messagingService, never()).handleWhatsAppMessage(any());
+    }
+
+    @Test
+    void shouldSanitizeXssInMessageText() throws Exception {
+        // Verifies that the endpoint accepts the request (returns 200) even with XSS-like input,
+        // because sanitisation strips non-printable/special chars before delegating to the service.
+        WhatsAppWebhook.Text text = new WhatsAppWebhook.Text();
+        text.setBody("<script>alert('xss')</script>Hello");
+
+        WhatsAppWebhook.Message message = new WhatsAppWebhook.Message();
+        message.setFrom("15550001234");
+        message.setId("wamid.abc123");
+        message.setType("text");
+        message.setText(text);
+
+        WhatsAppWebhook.Value value = new WhatsAppWebhook.Value();
+        value.setMessages(List.of(message));
+
+        WhatsAppWebhook.Change change = new WhatsAppWebhook.Change();
+        change.setField("messages");
+        change.setValue(value);
+
+        WhatsAppWebhook.Entry entry = new WhatsAppWebhook.Entry();
+        entry.setId("123456789");
+        entry.setChanges(List.of(change));
+
+        WhatsAppWebhook webhook = new WhatsAppWebhook();
+        webhook.setObject("whatsapp_business_account");
+        webhook.setEntry(List.of(entry));
+
+        mockMvc.perform(post("/api/webhooks/whatsapp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(webhook)))
+                .andExpect(status().isOk());
+
+        // Service is called — sanitisation happens inside the controller before the delegate call
+        verify(messagingService).handleWhatsAppMessage(any(WhatsAppWebhook.class));
     }
 }

--- a/backend/src/test/java/com/mindtrack/messaging/controller/WhatsAppWebhookHmacControllerTest.java
+++ b/backend/src/test/java/com/mindtrack/messaging/controller/WhatsAppWebhookHmacControllerTest.java
@@ -1,0 +1,150 @@
+package com.mindtrack.messaging.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mindtrack.messaging.dto.WhatsAppWebhook;
+import com.mindtrack.messaging.service.MessagingService;
+import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
+import java.util.List;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Tests HMAC-SHA256 signature verification for the WhatsApp webhook endpoint.
+ * Requires a non-blank {@code appSecret} to activate signature verification.
+ */
+@SpringBootTest(properties = {
+    "mindtrack.messaging.whatsapp.verify-token=test-verify-token",
+    "mindtrack.messaging.whatsapp.app-secret=test-app-secret"
+})
+@AutoConfigureMockMvc
+@ActiveProfiles("local")
+class WhatsAppWebhookHmacControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private MessagingService messagingService;
+
+    @Test
+    void shouldRejectWebhookWithInvalidHmacSignature() throws Exception {
+        WhatsAppWebhook.Change change = new WhatsAppWebhook.Change();
+        change.setField("messages");
+
+        WhatsAppWebhook.Entry entry = new WhatsAppWebhook.Entry();
+        entry.setId("123");
+        entry.setChanges(List.of(change));
+
+        WhatsAppWebhook webhook = new WhatsAppWebhook();
+        webhook.setObject("whatsapp_business_account");
+        webhook.setEntry(List.of(entry));
+
+        String body = objectMapper.writeValueAsString(webhook);
+
+        mockMvc.perform(post("/api/webhooks/whatsapp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-Hub-Signature-256", "sha256=deadbeefdeadbeef")
+                        .content(body))
+                .andExpect(status().isForbidden());
+
+        verify(messagingService, never()).handleWhatsAppMessage(any());
+    }
+
+    @Test
+    void shouldAcceptWebhookWithValidHmacSignature() throws Exception {
+        WhatsAppWebhook.Change change = new WhatsAppWebhook.Change();
+        change.setField("messages");
+
+        WhatsAppWebhook.Entry entry = new WhatsAppWebhook.Entry();
+        entry.setId("123456789");
+        entry.setChanges(List.of(change));
+
+        WhatsAppWebhook webhook = new WhatsAppWebhook();
+        webhook.setObject("whatsapp_business_account");
+        webhook.setEntry(List.of(entry));
+
+        String body = objectMapper.writeValueAsString(webhook);
+        String signature = computeHmac(body, "test-app-secret");
+
+        mockMvc.perform(post("/api/webhooks/whatsapp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-Hub-Signature-256", signature)
+                        .content(body))
+                .andExpect(status().isOk());
+
+        verify(messagingService).handleWhatsAppMessage(any(WhatsAppWebhook.class));
+    }
+
+    @Test
+    void shouldRejectWebhookWhenSignatureHeaderIsMissing() throws Exception {
+        WhatsAppWebhook.Change change = new WhatsAppWebhook.Change();
+        change.setField("messages");
+
+        WhatsAppWebhook.Entry entry = new WhatsAppWebhook.Entry();
+        entry.setId("123");
+        entry.setChanges(List.of(change));
+
+        WhatsAppWebhook webhook = new WhatsAppWebhook();
+        webhook.setObject("whatsapp_business_account");
+        webhook.setEntry(List.of(entry));
+
+        mockMvc.perform(post("/api/webhooks/whatsapp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        // No X-Hub-Signature-256 header
+                        .content(objectMapper.writeValueAsString(webhook)))
+                .andExpect(status().isForbidden());
+
+        verify(messagingService, never()).handleWhatsAppMessage(any());
+    }
+
+    @Test
+    void shouldRejectWebhookWithSignatureForWrongSecret() throws Exception {
+        WhatsAppWebhook.Change change = new WhatsAppWebhook.Change();
+        change.setField("messages");
+
+        WhatsAppWebhook.Entry entry = new WhatsAppWebhook.Entry();
+        entry.setId("123456789");
+        entry.setChanges(List.of(change));
+
+        WhatsAppWebhook webhook = new WhatsAppWebhook();
+        webhook.setObject("whatsapp_business_account");
+        webhook.setEntry(List.of(entry));
+
+        String body = objectMapper.writeValueAsString(webhook);
+        // Compute HMAC with the WRONG secret
+        String wrongSignature = computeHmac(body, "wrong-secret");
+
+        mockMvc.perform(post("/api/webhooks/whatsapp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-Hub-Signature-256", wrongSignature)
+                        .content(body))
+                .andExpect(status().isForbidden());
+
+        verify(messagingService, never()).handleWhatsAppMessage(any());
+    }
+
+    private String computeHmac(String body, String secret) throws Exception {
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+        byte[] hash = mac.doFinal(body.getBytes(StandardCharsets.UTF_8));
+        return "sha256=" + HexFormat.of().formatHex(hash);
+    }
+}

--- a/frontend/src/views/__tests__/GoalDetailView.test.ts
+++ b/frontend/src/views/__tests__/GoalDetailView.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { nextTick } from 'vue'
+import GoalDetailView from '../GoalDetailView.vue'
+import { useGoalsStore } from '@/stores/goals'
+
+const mockPush = vi.fn()
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { id: '1' } }),
+  useRouter: () => ({ push: mockPush }),
+}))
+
+const mockGet = vi.fn()
+const mockPost = vi.fn()
+const mockPatch = vi.fn()
+const mockDelete = vi.fn()
+
+vi.mock('@/services/api', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+    put: vi.fn(),
+    patch: (...args: unknown[]) => mockPatch(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
+  },
+}))
+
+const sampleGoal = {
+  id: 1,
+  title: 'Learn meditation',
+  description: 'Practice daily for 10 minutes',
+  category: 'Health',
+  targetDate: '2025-12-01',
+  status: 'IN_PROGRESS' as const,
+  validationStatus: null,
+  totalMilestones: 2,
+  completedMilestones: 1,
+  milestones: [
+    {
+      id: 10,
+      goalId: 1,
+      title: 'Complete intro course',
+      targetDate: '2025-06-01',
+      completedAt: '2025-05-15T00:00:00',
+      completed: true,
+      notes: 'Done!',
+      createdAt: '2025-01-01T00:00:00',
+    },
+    {
+      id: 11,
+      goalId: 1,
+      title: 'Practice 30 days streak',
+      targetDate: null,
+      completedAt: null,
+      completed: false,
+      notes: null,
+      createdAt: '2025-01-02T00:00:00',
+    },
+  ],
+  createdAt: '2025-01-01T10:00:00',
+  updatedAt: '2025-01-01T10:00:00',
+}
+
+describe('GoalDetailView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockPush.mockClear()
+    mockGet.mockReset().mockResolvedValue({ data: sampleGoal })
+    mockPost.mockReset()
+    mockPatch.mockReset().mockResolvedValue({ data: sampleGoal })
+    mockDelete.mockReset().mockResolvedValue({})
+  })
+
+  it('shows loading state before data arrives', async () => {
+    // Return a promise that never resolves so we can catch the loading state
+    mockGet.mockReturnValue(new Promise(() => {}))
+    const wrapper = mount(GoalDetailView)
+    await nextTick()
+    expect(wrapper.find('.loading').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Loading goal...')
+  })
+
+  it('renders goal title and details after loading', async () => {
+    const wrapper = mount(GoalDetailView)
+    await flushPromises()
+
+    expect(wrapper.find('.goal-title').text()).toBe('Learn meditation')
+    expect(wrapper.text()).toContain('Practice daily for 10 minutes')
+    expect(wrapper.find('.goal-category').text()).toBe('Health')
+  })
+
+  it('renders status badge with correct class', async () => {
+    const wrapper = mount(GoalDetailView)
+    await flushPromises()
+
+    const badge = wrapper.find('.status-badge')
+    expect(badge.text()).toBe('In Progress')
+    expect(badge.classes()).toContain('status-in-progress')
+  })
+
+  it('renders progress bar when milestones exist', async () => {
+    const wrapper = mount(GoalDetailView)
+    await flushPromises()
+
+    expect(wrapper.find('.progress-section').exists()).toBe(true)
+    expect(wrapper.text()).toContain('1/2')
+    expect(wrapper.text()).toContain('50%')
+  })
+
+  it('renders milestone list', async () => {
+    const wrapper = mount(GoalDetailView)
+    await flushPromises()
+
+    const items = wrapper.findAll('.milestone-item')
+    expect(items).toHaveLength(2)
+    expect(items[0].text()).toContain('Complete intro course')
+    expect(items[1].text()).toContain('Practice 30 days streak')
+  })
+
+  it('renders completed milestone with completed class', async () => {
+    const wrapper = mount(GoalDetailView)
+    await flushPromises()
+
+    const completedItem = wrapper.findAll('.milestone-item')[0]
+    expect(completedItem.classes()).toContain('completed')
+  })
+
+  it('shows empty milestones message when no milestones', async () => {
+    mockGet.mockResolvedValue({
+      data: { ...sampleGoal, milestones: [], totalMilestones: 0, completedMilestones: 0 },
+    })
+    const wrapper = mount(GoalDetailView)
+    await flushPromises()
+
+    expect(wrapper.find('.milestones-empty').exists()).toBe(true)
+    expect(wrapper.text()).toContain('No milestones yet')
+  })
+
+  it('shows error banner when store has error', async () => {
+    // Simulate error state by having the API reject; spy on fetchGoal to swallow
+    // the re-throw so the unhandled rejection doesn't leak into Vitest
+    mockGet.mockRejectedValue(new Error('Failed to load goal'))
+    const store = useGoalsStore()
+    const spy = vi.spyOn(store, 'fetchGoal').mockImplementation(async () => {
+      store.error = 'Failed to load goal'
+      return undefined as never
+    })
+    const wrapper = mount(GoalDetailView)
+    await flushPromises()
+    spy.mockRestore()
+
+    expect(wrapper.find('.error-banner').exists()).toBe(true)
+    expect(wrapper.find('.error-banner').text()).toContain('Failed to load goal')
+  })
+
+  it('navigates back to goals list when back button is clicked', async () => {
+    const wrapper = mount(GoalDetailView)
+    await flushPromises()
+
+    await wrapper.find('.btn-back').trigger('click')
+    expect(mockPush).toHaveBeenCalledWith({ name: 'goals' })
+  })
+
+  it('navigates to edit page when Edit Goal button is clicked', async () => {
+    const wrapper = mount(GoalDetailView)
+    await flushPromises()
+
+    await wrapper.find('.btn.btn-secondary').trigger('click')
+    expect(mockPush).toHaveBeenCalledWith({ name: 'goal-edit', params: { id: 1 } })
+  })
+
+  it('opens delete confirmation modal when Delete Goal is clicked', async () => {
+    const wrapper = mount(GoalDetailView)
+    await flushPromises()
+
+    expect(wrapper.find('.modal-overlay').exists()).toBe(false)
+    await wrapper.find('.btn.btn-danger').trigger('click')
+    expect(wrapper.find('.modal-overlay').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Delete Goal')
+  })
+
+  it('closes delete modal when Cancel is clicked', async () => {
+    const wrapper = mount(GoalDetailView)
+    await flushPromises()
+
+    await wrapper.find('.btn.btn-danger').trigger('click')
+    expect(wrapper.find('.modal-overlay').exists()).toBe(true)
+
+    await wrapper.find('.modal-actions .btn-secondary').trigger('click')
+    expect(wrapper.find('.modal-overlay').exists()).toBe(false)
+  })
+
+  it('deletes goal and navigates to goals list', async () => {
+    const wrapper = mount(GoalDetailView)
+    await flushPromises()
+
+    await wrapper.find('.btn.btn-danger').trigger('click')
+    await wrapper.find('.modal-actions .btn-danger').trigger('click')
+    await flushPromises()
+
+    expect(mockDelete).toHaveBeenCalledWith('/goals/1')
+    expect(mockPush).toHaveBeenCalledWith({ name: 'goals' })
+  })
+
+  it('toggles milestone when toggle button is clicked', async () => {
+    mockPatch.mockResolvedValue({
+      data: { ...sampleGoal.milestones[1], completed: true, completedAt: '2025-06-01T00:00:00' },
+    })
+    const wrapper = mount(GoalDetailView)
+    await flushPromises()
+
+    const toggleButtons = wrapper.findAll('.milestone-toggle')
+    await toggleButtons[1].trigger('click')
+    await flushPromises()
+
+    expect(mockPatch).toHaveBeenCalledWith('/goals/1/milestones/11/toggle')
+  })
+
+  it('calls updateStatus when a status button is clicked', async () => {
+    mockPatch.mockResolvedValue({ data: { ...sampleGoal, status: 'COMPLETED' } })
+    const wrapper = mount(GoalDetailView)
+    await flushPromises()
+
+    const completedBtn = wrapper.findAll('.btn-status').find((btn) => btn.text() === 'Completed')
+    await completedBtn!.trigger('click')
+    await flushPromises()
+
+    expect(mockPatch).toHaveBeenCalledWith('/goals/1/status', { status: 'COMPLETED' })
+  })
+
+  it('shows milestone form when Add Milestone button is clicked', async () => {
+    const wrapper = mount(GoalDetailView)
+    await flushPromises()
+
+    expect(wrapper.find('.milestone-form').exists()).toBe(false)
+    await wrapper.find('.milestones-header .btn-primary').trigger('click')
+    expect(wrapper.find('.milestone-form').exists()).toBe(true)
+  })
+
+  it('hides milestone form when Cancel is clicked inside it', async () => {
+    const wrapper = mount(GoalDetailView)
+    await flushPromises()
+
+    await wrapper.find('.milestones-header .btn-primary').trigger('click')
+    expect(wrapper.find('.milestone-form').exists()).toBe(true)
+
+    // Click again to cancel (button toggles)
+    await wrapper.find('.milestones-header .btn-primary').trigger('click')
+    expect(wrapper.find('.milestone-form').exists()).toBe(false)
+  })
+
+  it('submits milestone form and calls addMilestone', async () => {
+    const newMilestone = {
+      id: 12,
+      goalId: 1,
+      title: 'New milestone',
+      targetDate: null,
+      completedAt: null,
+      completed: false,
+      notes: null,
+      createdAt: '2025-01-03T00:00:00',
+    }
+    mockPost.mockResolvedValue({ data: newMilestone })
+
+    const wrapper = mount(GoalDetailView)
+    await flushPromises()
+
+    await wrapper.find('.milestones-header .btn-primary').trigger('click')
+    await wrapper.find('input[placeholder="Milestone title *"]').setValue('New milestone')
+    await wrapper.find('.milestone-form').trigger('submit')
+    await flushPromises()
+
+    expect(mockPost).toHaveBeenCalledWith(
+      '/goals/1/milestones',
+      expect.objectContaining({ title: 'New milestone' }),
+    )
+  })
+
+  it('does not submit milestone form when title is blank', async () => {
+    const wrapper = mount(GoalDetailView)
+    await flushPromises()
+
+    await wrapper.find('.milestones-header .btn-primary').trigger('click')
+    // leave title empty
+    await wrapper.find('.milestone-form').trigger('submit')
+    await flushPromises()
+
+    expect(mockPost).not.toHaveBeenCalled()
+  })
+
+  it('renders target date when present', async () => {
+    const wrapper = mount(GoalDetailView)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Target:')
+  })
+})

--- a/frontend/src/views/__tests__/InterviewDetailView.test.ts
+++ b/frontend/src/views/__tests__/InterviewDetailView.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { nextTick } from 'vue'
+import InterviewDetailView from '../InterviewDetailView.vue'
+import { useInterviewsStore } from '@/stores/interviews'
+
+const mockPush = vi.fn()
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { id: '5' } }),
+  useRouter: () => ({ push: mockPush }),
+}))
+
+const mockGet = vi.fn()
+const mockDelete = vi.fn()
+
+vi.mock('@/services/api', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: (...args: unknown[]) => mockDelete(...args),
+  },
+}))
+
+const sampleInterview = {
+  id: 5,
+  interviewDate: '2025-03-10',
+  moodBefore: 4,
+  moodAfter: 7,
+  topics: ['anxiety', 'sleep', 'medication'],
+  medicationChanges: 'Increased Sertraline to 100mg',
+  recommendations: 'Practice breathing exercises daily',
+  notes: 'Good progress noted',
+  hasAudio: false,
+  transcriptionText: null,
+  audioExpiresAt: null,
+  createdAt: '2025-03-10T09:00:00',
+  updatedAt: '2025-03-10T09:00:00',
+}
+
+describe('InterviewDetailView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockPush.mockClear()
+    mockGet.mockReset().mockResolvedValue({ data: sampleInterview })
+    mockDelete.mockReset().mockResolvedValue({})
+  })
+
+  it('shows loading state before data arrives', async () => {
+    mockGet.mockReturnValue(new Promise(() => {}))
+    const wrapper = mount(InterviewDetailView)
+    await nextTick()
+    expect(wrapper.find('.loading').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Loading interview...')
+  })
+
+  it('renders interview details after loading', async () => {
+    const wrapper = mount(InterviewDetailView)
+    await flushPromises()
+
+    // Date formatted as "Monday, March 10, 2025"
+    expect(wrapper.find('h1').text()).toContain('March 10, 2025')
+  })
+
+  it('renders mood before and after', async () => {
+    const wrapper = mount(InterviewDetailView)
+    await flushPromises()
+
+    const moodNumbers = wrapper.findAll('.mood-number')
+    expect(moodNumbers[0].text()).toBe('4/10')
+    expect(moodNumbers[1].text()).toBe('7/10')
+  })
+
+  it('renders null mood as "Not recorded"', async () => {
+    mockGet.mockResolvedValue({
+      data: { ...sampleInterview, moodBefore: null, moodAfter: null },
+    })
+    const wrapper = mount(InterviewDetailView)
+    await flushPromises()
+
+    const moodNumbers = wrapper.findAll('.mood-number')
+    expect(moodNumbers[0].text()).toBe('Not recorded')
+    expect(moodNumbers[1].text()).toBe('Not recorded')
+  })
+
+  it('renders topic chips', async () => {
+    const wrapper = mount(InterviewDetailView)
+    await flushPromises()
+
+    const chips = wrapper.findAll('.topic-chip')
+    expect(chips).toHaveLength(3)
+    expect(chips[0].text()).toBe('anxiety')
+    expect(chips[1].text()).toBe('sleep')
+    expect(chips[2].text()).toBe('medication')
+  })
+
+  it('renders medication changes section', async () => {
+    const wrapper = mount(InterviewDetailView)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Medication changes')
+    expect(wrapper.text()).toContain('Increased Sertraline to 100mg')
+  })
+
+  it('renders recommendations section', async () => {
+    const wrapper = mount(InterviewDetailView)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Recommendations')
+    expect(wrapper.text()).toContain('Practice breathing exercises daily')
+  })
+
+  it('renders notes section', async () => {
+    const wrapper = mount(InterviewDetailView)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Notes')
+    expect(wrapper.text()).toContain('Good progress noted')
+  })
+
+  it('hides optional sections when fields are null', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        ...sampleInterview,
+        topics: [],
+        medicationChanges: null,
+        recommendations: null,
+        notes: null,
+      },
+    })
+    const wrapper = mount(InterviewDetailView)
+    await flushPromises()
+
+    expect(wrapper.find('.topics-section').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('Medication changes')
+    expect(wrapper.text()).not.toContain('Recommendations')
+    expect(wrapper.text()).not.toContain('Notes')
+  })
+
+  it('shows error message when fetch fails', async () => {
+    // Spy on fetchInterview to set error state without re-throwing
+    const store = useInterviewsStore()
+    const spy = vi.spyOn(store, 'fetchInterview').mockImplementation(async () => {
+      store.error = 'Failed to load interview'
+      return undefined as never
+    })
+    const wrapper = mount(InterviewDetailView)
+    await flushPromises()
+    spy.mockRestore()
+
+    expect(wrapper.find('.error-message').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Failed to load interview')
+  })
+
+  it('retry button calls fetchInterview again', async () => {
+    // First call fails (set error), second call succeeds
+    const store = useInterviewsStore()
+    let callCount = 0
+    const spy = vi.spyOn(store, 'fetchInterview').mockImplementation(async () => {
+      callCount++
+      if (callCount === 1) {
+        store.error = 'Failed to load interview'
+        return undefined as never
+      }
+      store.error = null
+      store.currentInterview = sampleInterview
+      return sampleInterview as never
+    })
+    const wrapper = mount(InterviewDetailView)
+    await flushPromises()
+
+    expect(wrapper.find('.error-message').exists()).toBe(true)
+    await wrapper.find('.error-message .btn').trigger('click')
+    await flushPromises()
+    spy.mockRestore()
+
+    expect(callCount).toBe(2)
+  })
+
+  it('navigates back when back button is clicked', async () => {
+    const wrapper = mount(InterviewDetailView)
+    await flushPromises()
+
+    await wrapper.find('.btn-back').trigger('click')
+    expect(mockPush).toHaveBeenCalledWith({ name: 'interviews' })
+  })
+
+  it('shows Edit and Delete buttons when interview is loaded', async () => {
+    const wrapper = mount(InterviewDetailView)
+    await flushPromises()
+
+    const buttons = wrapper.findAll('.header-actions .btn')
+    expect(buttons).toHaveLength(2)
+    expect(buttons[0].text()).toBe('Edit')
+    expect(buttons[1].text()).toBe('Delete')
+  })
+
+  it('navigates to edit page when Edit is clicked', async () => {
+    const wrapper = mount(InterviewDetailView)
+    await flushPromises()
+
+    await wrapper.find('.header-actions .btn-secondary').trigger('click')
+    expect(mockPush).toHaveBeenCalledWith({ name: 'interview-edit', params: { id: 5 } })
+  })
+
+  it('opens delete confirmation modal when Delete is clicked', async () => {
+    const wrapper = mount(InterviewDetailView)
+    await flushPromises()
+
+    expect(wrapper.find('.modal-overlay').exists()).toBe(false)
+    await wrapper.find('.header-actions .btn-danger').trigger('click')
+    expect(wrapper.find('.modal-overlay').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Delete interview?')
+  })
+
+  it('closes delete modal when Cancel is clicked', async () => {
+    const wrapper = mount(InterviewDetailView)
+    await flushPromises()
+
+    await wrapper.find('.header-actions .btn-danger').trigger('click')
+    expect(wrapper.find('.modal-overlay').exists()).toBe(true)
+
+    await wrapper.find('.modal-actions .btn-secondary').trigger('click')
+    expect(wrapper.find('.modal-overlay').exists()).toBe(false)
+  })
+
+  it('deletes interview and navigates to interviews list', async () => {
+    const wrapper = mount(InterviewDetailView)
+    await flushPromises()
+
+    await wrapper.find('.header-actions .btn-danger').trigger('click')
+    await wrapper.find('.modal-actions .btn-danger').trigger('click')
+    await flushPromises()
+
+    expect(mockDelete).toHaveBeenCalledWith('/interviews/5')
+    expect(mockPush).toHaveBeenCalledWith({ name: 'interviews' })
+  })
+
+  it('renders footer with created timestamp', async () => {
+    const wrapper = mount(InterviewDetailView)
+    await flushPromises()
+
+    expect(wrapper.find('.detail-footer').exists()).toBe(true)
+    expect(wrapper.find('.detail-footer').text()).toContain('Created')
+  })
+})

--- a/frontend/src/views/__tests__/JournalDetailView.test.ts
+++ b/frontend/src/views/__tests__/JournalDetailView.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { nextTick } from 'vue'
+import JournalDetailView from '../JournalDetailView.vue'
+import { useJournalStore } from '@/stores/journal'
+
+const mockPush = vi.fn()
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { id: '3' } }),
+  useRouter: () => ({ push: mockPush }),
+}))
+
+const mockGet = vi.fn()
+const mockPatch = vi.fn()
+const mockDelete = vi.fn()
+
+vi.mock('@/services/api', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: (...args: unknown[]) => mockPatch(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
+  },
+}))
+
+const sampleEntry = {
+  id: 3,
+  entryDate: '2025-04-05',
+  title: 'Morning reflection',
+  content: 'Today I felt much calmer after meditating.',
+  mood: 8,
+  tags: ['meditation', 'calm'],
+  sharedWithTherapist: false,
+  createdAt: '2025-04-05T08:00:00',
+  updatedAt: '2025-04-05T08:00:00',
+}
+
+describe('JournalDetailView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockPush.mockClear()
+    mockGet.mockReset().mockResolvedValue({ data: sampleEntry })
+    mockPatch.mockReset().mockResolvedValue({ data: { ...sampleEntry, sharedWithTherapist: true } })
+    mockDelete.mockReset().mockResolvedValue({})
+  })
+
+  it('shows loading state before data arrives', async () => {
+    mockGet.mockReturnValue(new Promise(() => {}))
+    const wrapper = mount(JournalDetailView)
+    await nextTick()
+    expect(wrapper.find('.loading').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Loading entry...')
+  })
+
+  it('renders journal entry details after loading', async () => {
+    const wrapper = mount(JournalDetailView)
+    await flushPromises()
+
+    expect(wrapper.find('.entry-title').text()).toBe('Morning reflection')
+    expect(wrapper.find('.entry-content').text()).toContain('Today I felt much calmer')
+  })
+
+  it('renders entry date', async () => {
+    const wrapper = mount(JournalDetailView)
+    await flushPromises()
+
+    expect(wrapper.find('.entry-date').text()).toContain('April 5, 2025')
+  })
+
+  it('renders mood with emoji', async () => {
+    const wrapper = mount(JournalDetailView)
+    await flushPromises()
+
+    // mood 8 → 😊 emoji
+    const mood = wrapper.find('.entry-mood')
+    expect(mood.exists()).toBe(true)
+    expect(mood.text()).toContain('8/10')
+  })
+
+  it('renders tags', async () => {
+    const wrapper = mount(JournalDetailView)
+    await flushPromises()
+
+    const tags = wrapper.findAll('.tag')
+    expect(tags).toHaveLength(2)
+    expect(tags[0].text()).toBe('meditation')
+    expect(tags[1].text()).toBe('calm')
+  })
+
+  it('shows private sharing badge when not shared', async () => {
+    const wrapper = mount(JournalDetailView)
+    await flushPromises()
+
+    const badge = wrapper.find('.sharing-badge')
+    expect(badge.classes()).toContain('private')
+    expect(badge.text()).toBe('Private entry')
+  })
+
+  it('shows shared sharing badge when shared', async () => {
+    mockGet.mockResolvedValue({ data: { ...sampleEntry, sharedWithTherapist: true } })
+    const wrapper = mount(JournalDetailView)
+    await flushPromises()
+
+    const badge = wrapper.find('.sharing-badge')
+    expect(badge.classes()).toContain('shared')
+    expect(badge.text()).toBe('Shared with therapist')
+  })
+
+  it('shows correct toggle sharing button text when private', async () => {
+    const wrapper = mount(JournalDetailView)
+    await flushPromises()
+
+    expect(wrapper.find('.btn-link').text()).toBe('Share with therapist')
+  })
+
+  it('shows correct toggle sharing button text when shared', async () => {
+    mockGet.mockResolvedValue({ data: { ...sampleEntry, sharedWithTherapist: true } })
+    const wrapper = mount(JournalDetailView)
+    await flushPromises()
+
+    expect(wrapper.find('.btn-link').text()).toBe('Make private')
+  })
+
+  it('calls toggleSharing when the sharing link button is clicked', async () => {
+    const wrapper = mount(JournalDetailView)
+    await flushPromises()
+
+    await wrapper.find('.btn-link').trigger('click')
+    await flushPromises()
+
+    expect(mockPatch).toHaveBeenCalledWith('/journal/3/share')
+  })
+
+  it('shows error banner when fetch fails', async () => {
+    // Spy on fetchEntry to set error state without re-throwing
+    const store = useJournalStore()
+    const spy = vi.spyOn(store, 'fetchEntry').mockImplementation(async () => {
+      store.error = 'Failed to load journal entry'
+      return undefined as never
+    })
+    const wrapper = mount(JournalDetailView)
+    await flushPromises()
+    spy.mockRestore()
+
+    expect(wrapper.find('.error-banner').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Failed to load journal entry')
+  })
+
+  it('clears error when dismiss button is clicked', async () => {
+    // Spy on fetchEntry to set error state without re-throwing
+    const store = useJournalStore()
+    const spy = vi.spyOn(store, 'fetchEntry').mockImplementation(async () => {
+      store.error = 'Failed to load journal entry'
+      return undefined as never
+    })
+    const wrapper = mount(JournalDetailView)
+    await flushPromises()
+    spy.mockRestore()
+
+    expect(wrapper.find('.error-banner').exists()).toBe(true)
+    await wrapper.find('.error-dismiss').trigger('click')
+    expect(wrapper.find('.error-banner').exists()).toBe(false)
+  })
+
+  it('navigates back to journal list when back button is clicked', async () => {
+    const wrapper = mount(JournalDetailView)
+    await flushPromises()
+
+    await wrapper.find('.btn-back').trigger('click')
+    expect(mockPush).toHaveBeenCalledWith({ name: 'journal' })
+  })
+
+  it('navigates to edit page when Edit button is clicked', async () => {
+    const wrapper = mount(JournalDetailView)
+    await flushPromises()
+
+    await wrapper.find('.entry-actions .btn-secondary').trigger('click')
+    expect(mockPush).toHaveBeenCalledWith({ name: 'journal-edit', params: { id: 3 } })
+  })
+
+  it('opens delete confirmation modal when Delete is clicked', async () => {
+    const wrapper = mount(JournalDetailView)
+    await flushPromises()
+
+    expect(wrapper.find('.modal-overlay').exists()).toBe(false)
+    await wrapper.find('.entry-actions .btn-danger').trigger('click')
+    expect(wrapper.find('.modal-overlay').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Delete Entry')
+  })
+
+  it('closes delete modal when Cancel is clicked', async () => {
+    const wrapper = mount(JournalDetailView)
+    await flushPromises()
+
+    await wrapper.find('.entry-actions .btn-danger').trigger('click')
+    expect(wrapper.find('.modal-overlay').exists()).toBe(true)
+
+    await wrapper.find('.modal-actions .btn-secondary').trigger('click')
+    expect(wrapper.find('.modal-overlay').exists()).toBe(false)
+  })
+
+  it('deletes entry and navigates to journal list', async () => {
+    const wrapper = mount(JournalDetailView)
+    await flushPromises()
+
+    await wrapper.find('.entry-actions .btn-danger').trigger('click')
+    await wrapper.find('.modal-actions .btn-danger').trigger('click')
+    await flushPromises()
+
+    expect(mockDelete).toHaveBeenCalledWith('/journal/3')
+    expect(mockPush).toHaveBeenCalledWith({ name: 'journal' })
+  })
+
+  it('hides title when entry has no title', async () => {
+    mockGet.mockResolvedValue({ data: { ...sampleEntry, title: null } })
+    const wrapper = mount(JournalDetailView)
+    await flushPromises()
+
+    expect(wrapper.find('.entry-title').exists()).toBe(false)
+  })
+
+  it('hides content section when entry has no content', async () => {
+    mockGet.mockResolvedValue({ data: { ...sampleEntry, content: null } })
+    const wrapper = mount(JournalDetailView)
+    await flushPromises()
+
+    expect(wrapper.find('.entry-content').exists()).toBe(false)
+  })
+
+  it('hides tags section when entry has no tags', async () => {
+    mockGet.mockResolvedValue({ data: { ...sampleEntry, tags: [] } })
+    const wrapper = mount(JournalDetailView)
+    await flushPromises()
+
+    expect(wrapper.find('.entry-tags').exists()).toBe(false)
+  })
+
+  it('hides mood when entry has no mood', async () => {
+    mockGet.mockResolvedValue({ data: { ...sampleEntry, mood: null } })
+    const wrapper = mount(JournalDetailView)
+    await flushPromises()
+
+    expect(wrapper.find('.entry-mood').exists()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add coverage for GoalDetailView, InterviewDetailView, and JournalDetailView
- expand backend coverage around conversation/context builder paths and WhatsApp webhook validation
- add HMAC signature coverage for the WhatsApp webhook endpoint

## Testing
- mvn -Dtest=ContextBuilderTest,ConversationServiceTest,WhatsAppWebhookControllerTest,WhatsAppWebhookHmacControllerTest test
- npm run test:unit -- src/views/__tests__/GoalDetailView.test.ts src/views/__tests__/InterviewDetailView.test.ts src/views/__tests__/JournalDetailView.test.ts
- git push -u origin test/216-improve-sonar-coverage

Closes #216