### PR TITLE
test(coverage): raise frontend and backend coverage

### DIFF
--- a/backend/src/test/java/com/mindtrack/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/mindtrack/auth/controller/AuthControllerTest.java
@@ -2,15 +2,20 @@ package com.mindtrack.auth.controller;
 
 import com.mindtrack.auth.service.JwtService;
 import com.mindtrack.auth.service.RefreshTokenService;
+import com.mindtrack.auth.service.AccountDeletionService;
+import com.mindtrack.auth.service.TherapistRegistrationService;
 import com.mindtrack.auth.service.UserService;
+import com.mindtrack.auth.repository.UserRepository;
 import com.mindtrack.common.model.Role;
 import com.mindtrack.common.model.User;
 import com.mindtrack.profile.model.UserProfile;
 import com.mindtrack.profile.service.ProfileService;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -25,15 +30,19 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@SpringBootTest(properties = "mindtrack.auth.cookie-secure=false")
 @AutoConfigureMockMvc
 @ActiveProfiles("local")
 class AuthControllerTest {
@@ -52,6 +61,15 @@ class AuthControllerTest {
 
     @MockitoBean
     private RefreshTokenService refreshTokenService;
+
+    @MockitoBean
+    private TherapistRegistrationService therapistRegistrationService;
+
+    @MockitoBean
+    private UserRepository userRepository;
+
+    @MockitoBean
+    private AccountDeletionService accountDeletionService;
 
     private static UsernamePasswordAuthenticationToken mockAuth(Long userId) {
         return new UsernamePasswordAuthenticationToken(
@@ -144,6 +162,86 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"isPatient\":true,\"isTherapist\":false}"))
                 .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void shouldRedeemTherapistTokenAndReturnUpdatedAuthResponse() throws Exception {
+        User user = createUser(1L, "test@example.com", "Test User", "THERAPIST");
+        UserProfile profile = createProfile(true, true);
+        when(userService.findById(1L)).thenReturn(Optional.of(user));
+        when(profileService.getOrCreateProfile(1L)).thenReturn(profile);
+        when(jwtService.generateToken(anyLong(), anyString(), anyString(), anyBoolean(), anyBoolean(), anyInt()))
+                .thenReturn("therapist-jwt");
+        when(refreshTokenService.createRefreshToken(1L)).thenReturn("refresh-123");
+
+        mockMvc.perform(post("/api/auth/therapist-register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"token\":\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\"}")
+                        .with(authentication(mockAuth(1L))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.token").value("therapist-jwt"))
+                .andExpect(jsonPath("$.refreshToken").value("refresh-123"))
+                .andExpect(jsonPath("$.role").value("THERAPIST"))
+                .andExpect(jsonPath("$.isPatient").value(true))
+                .andExpect(jsonPath("$.isTherapist").value(true));
+
+        verify(therapistRegistrationService).redeemToken(
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", 1L);
+    }
+
+    @Test
+    void shouldRefreshTokens() throws Exception {
+        User user = createUser(2L, "refresh@example.com", "Refresh User", "USER");
+        UserProfile profile = createProfile(true, false);
+        user.setTokenVersion(7);
+        when(refreshTokenService.rotateRefreshToken("refresh-old")).thenReturn(2L);
+        when(userRepository.findById(2L)).thenReturn(Optional.of(user));
+        when(profileService.getOrCreateProfile(2L)).thenReturn(profile);
+        when(jwtService.generateToken(2L, "refresh@example.com", "USER", true, false, 7))
+                .thenReturn("jwt-refreshed");
+        when(refreshTokenService.createRefreshToken(2L)).thenReturn("refresh-new");
+
+        mockMvc.perform(post("/api/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"refreshToken\":\"refresh-old\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.token").value("jwt-refreshed"))
+                .andExpect(jsonPath("$.refreshToken").value("refresh-new"));
+    }
+
+    @Test
+    void shouldReturnUnauthorizedWhenRefreshUserIsMissing() throws Exception {
+        when(refreshTokenService.rotateRefreshToken("missing")).thenReturn(99L);
+        when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(post("/api/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"refreshToken\":\"missing\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void shouldDeleteAccountAndClearCookie() throws Exception {
+        mockMvc.perform(delete("/api/auth/account")
+                        .with(authentication(mockAuth(1L)))
+                        .with(request -> {
+                            request.setRemoteAddr("10.10.10.10");
+                            return request;
+                        }))
+                .andExpect(status().isNoContent())
+                .andExpect(header().string(HttpHeaders.SET_COOKIE, org.hamcrest.Matchers.containsString("Max-Age=0")))
+                .andExpect(header().string(HttpHeaders.SET_COOKIE, org.hamcrest.Matchers.containsString("auth_token=")));
+
+        verify(accountDeletionService).requestDeletion(1L, "10.10.10.10");
+    }
+
+    @Test
+    void shouldClearCookieOnLogoutResponse() throws Exception {
+        mockMvc.perform(post("/api/auth/logout")
+                        .with(authentication(mockAuth(1L)))
+                        .cookie(new Cookie("auth_token", "still-set")))
+                .andExpect(status().isNoContent())
+                .andExpect(header().string(HttpHeaders.SET_COOKIE, org.hamcrest.Matchers.containsString("Max-Age=0")));
     }
 
     private User createUser(Long id, String email, String name, String roleName) {

--- a/backend/src/test/java/com/mindtrack/interview/service/LocalStorageServiceTest.java
+++ b/backend/src/test/java/com/mindtrack/interview/service/LocalStorageServiceTest.java
@@ -1,0 +1,68 @@
+package com.mindtrack.interview.service;
+
+import com.mindtrack.interview.config.StorageProperties;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LocalStorageServiceTest {
+
+    @TempDir
+    Path tempDir;
+
+    private LocalStorageService service;
+
+    @BeforeEach
+    void setUp() {
+        StorageProperties properties = new StorageProperties();
+        properties.setLocalStoragePath(tempDir.resolve("audio").toString());
+        service = new LocalStorageService(properties);
+    }
+
+    @Test
+    void shouldStoreDownloadAndExposeLocalFile() {
+        byte[] content = "mindtrack-audio".getBytes(StandardCharsets.UTF_8);
+
+        service.upload("interviews/1/audio.webm",
+                new ByteArrayInputStream(content), "audio/webm", content.length);
+
+        assertArrayEquals(content, service.download("interviews/1/audio.webm"));
+        assertTrue(service.generateAccessUrl("interviews/1/audio.webm").startsWith("file:"));
+    }
+
+    @Test
+    void shouldDeleteStoredFile() throws Exception {
+        byte[] content = "to-delete".getBytes(StandardCharsets.UTF_8);
+        service.upload("interviews/2/audio.webm",
+                new ByteArrayInputStream(content), "audio/webm", content.length);
+
+        Path storedPath = tempDir.resolve("audio/interviews/2/audio.webm");
+        assertTrue(Files.exists(storedPath));
+
+        service.delete("interviews/2/audio.webm");
+
+        assertFalse(Files.exists(storedPath));
+    }
+
+    @Test
+    void shouldRejectPathTraversalKeys() {
+        byte[] content = "escape".getBytes(StandardCharsets.UTF_8);
+
+        assertThrows(IllegalArgumentException.class, () -> service.upload(
+                "../escape.webm",
+                new ByteArrayInputStream(content),
+                "audio/webm",
+                content.length));
+        assertThrows(IllegalArgumentException.class, () -> service.generateAccessUrl("../escape.webm"));
+        assertThrows(IllegalArgumentException.class, () -> service.download("../escape.webm"));
+    }
+}

--- a/backend/src/test/java/com/mindtrack/interview/service/S3StorageServiceTest.java
+++ b/backend/src/test/java/com/mindtrack/interview/service/S3StorageServiceTest.java
@@ -1,0 +1,111 @@
+package com.mindtrack.interview.service;
+
+import com.mindtrack.interview.config.StorageProperties;
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class S3StorageServiceTest {
+
+    @Mock
+    private S3Client s3Client;
+
+    @Mock
+    private S3Presigner s3Presigner;
+
+    @Mock
+    private PresignedGetObjectRequest presignedGetObjectRequest;
+
+    private S3StorageService service;
+
+    @BeforeEach
+    void setUp() {
+        StorageProperties properties = new StorageProperties();
+        properties.setBucketName("mindtrack-audio-test");
+        properties.setPresignedUrlExpiryMinutes(15);
+        service = new S3StorageService(s3Client, s3Presigner, properties);
+    }
+
+    @Test
+    void shouldUploadFileToConfiguredBucket() {
+        byte[] content = "s3-audio".getBytes(StandardCharsets.UTF_8);
+
+        service.upload("interviews/1/audio.webm",
+                new ByteArrayInputStream(content), "audio/webm", content.length);
+
+        ArgumentCaptor<PutObjectRequest> requestCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        verify(s3Client).putObject(requestCaptor.capture(), any(RequestBody.class));
+        PutObjectRequest request = requestCaptor.getValue();
+        assertEquals("mindtrack-audio-test", request.bucket());
+        assertEquals("interviews/1/audio.webm", request.key());
+        assertEquals("audio/webm", request.contentType());
+    }
+
+    @Test
+    void shouldGeneratePresignedAccessUrl() throws Exception {
+        when(presignedGetObjectRequest.url())
+                .thenReturn(URI.create("https://example.com/audio.webm?sig=123").toURL());
+        when(s3Presigner.presignGetObject(any(GetObjectPresignRequest.class)))
+                .thenReturn(presignedGetObjectRequest);
+
+        String url = service.generateAccessUrl("interviews/3/audio.webm");
+
+        ArgumentCaptor<GetObjectPresignRequest> requestCaptor =
+                ArgumentCaptor.forClass(GetObjectPresignRequest.class);
+        verify(s3Presigner).presignGetObject(requestCaptor.capture());
+        GetObjectPresignRequest request = requestCaptor.getValue();
+        assertEquals(Duration.ofMinutes(15), request.signatureDuration());
+        assertEquals("mindtrack-audio-test", request.getObjectRequest().bucket());
+        assertEquals("interviews/3/audio.webm", request.getObjectRequest().key());
+        assertEquals("https://example.com/audio.webm?sig=123", url);
+    }
+
+    @Test
+    void shouldDownloadBytesFromS3() {
+        byte[] content = "downloaded".getBytes(StandardCharsets.UTF_8);
+        when(s3Client.getObjectAsBytes(any(GetObjectRequest.class)))
+                .thenReturn(ResponseBytes.fromByteArray(GetObjectResponse.builder().build(), content));
+
+        byte[] result = service.download("interviews/4/audio.webm");
+
+        ArgumentCaptor<GetObjectRequest> requestCaptor = ArgumentCaptor.forClass(GetObjectRequest.class);
+        verify(s3Client).getObjectAsBytes(requestCaptor.capture());
+        assertEquals("mindtrack-audio-test", requestCaptor.getValue().bucket());
+        assertEquals("interviews/4/audio.webm", requestCaptor.getValue().key());
+        assertArrayEquals(content, result);
+    }
+
+    @Test
+    void shouldDeleteObjectFromS3() {
+        service.delete("interviews/5/audio.webm");
+
+        ArgumentCaptor<DeleteObjectRequest> requestCaptor = ArgumentCaptor.forClass(DeleteObjectRequest.class);
+        verify(s3Client).deleteObject(requestCaptor.capture());
+        assertEquals("mindtrack-audio-test", requestCaptor.getValue().bucket());
+        assertEquals("interviews/5/audio.webm", requestCaptor.getValue().key());
+    }
+}

--- a/backend/src/test/java/com/mindtrack/interview/service/TranscriptionServiceTest.java
+++ b/backend/src/test/java/com/mindtrack/interview/service/TranscriptionServiceTest.java
@@ -1,0 +1,107 @@
+package com.mindtrack.interview.service;
+
+import com.mindtrack.interview.config.WhisperProperties;
+import com.mindtrack.interview.model.Interview;
+import com.mindtrack.interview.model.TranscriptionStatus;
+import com.mindtrack.interview.repository.InterviewRepository;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestTemplate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TranscriptionServiceTest {
+
+    @Mock
+    private InterviewRepository interviewRepository;
+
+    @Mock
+    private StorageService storageService;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    private TranscriptionService service;
+
+    @BeforeEach
+    void setUp() {
+        WhisperProperties whisperProperties = new WhisperProperties();
+        whisperProperties.setWhisperApiKey("test-key");
+        whisperProperties.setWhisperApiUrl("https://example.com/transcribe");
+        service = new TranscriptionService(interviewRepository, storageService, whisperProperties, restTemplate);
+    }
+
+    @Test
+    void shouldSaveCompletedTranscriptWhenWhisperSucceeds() {
+        Interview interview = interview(1L);
+        when(storageService.download("audio/key.webm")).thenReturn("audio".getBytes());
+        when(restTemplate.postForObject(eq("https://example.com/transcribe"), any(), eq(Map.class)))
+                .thenReturn(Map.of("text", "Transcribed text"));
+        when(interviewRepository.findById(1L)).thenReturn(Optional.of(interview));
+
+        service.transcribeAsync(1L, "audio/key.webm");
+
+        ArgumentCaptor<Interview> interviewCaptor = ArgumentCaptor.forClass(Interview.class);
+        verify(interviewRepository).save(interviewCaptor.capture());
+        Interview saved = interviewCaptor.getValue();
+        assertEquals(TranscriptionStatus.COMPLETED, saved.getTranscriptionStatus());
+        assertEquals("Transcribed text", saved.getTranscriptionText());
+        assertNotNull(saved.getUpdatedAt());
+    }
+
+    @Test
+    void shouldMarkInterviewFailedWhenTranscriptionThrows() {
+        Interview interview = interview(2L);
+        when(storageService.download("audio/failure.webm")).thenThrow(new RuntimeException("boom"));
+        when(interviewRepository.findById(2L)).thenReturn(Optional.of(interview));
+
+        service.transcribeAsync(2L, "audio/failure.webm");
+
+        ArgumentCaptor<Interview> interviewCaptor = ArgumentCaptor.forClass(Interview.class);
+        verify(interviewRepository).save(interviewCaptor.capture());
+        Interview saved = interviewCaptor.getValue();
+        assertEquals(TranscriptionStatus.FAILED, saved.getTranscriptionStatus());
+        assertNull(saved.getTranscriptionText());
+        assertNotNull(saved.getUpdatedAt());
+    }
+
+    @Test
+    void shouldPersistNullTranscriptWhenWhisperReturnsNoText() {
+        Interview interview = interview(3L);
+        when(storageService.download("audio/empty.webm")).thenReturn("audio".getBytes());
+        when(restTemplate.postForObject(eq("https://example.com/transcribe"), any(), eq(Map.class)))
+                .thenReturn(Map.of());
+        when(interviewRepository.findById(3L)).thenReturn(Optional.of(interview));
+
+        service.transcribeAsync(3L, "audio/empty.webm");
+
+        ArgumentCaptor<Interview> interviewCaptor = ArgumentCaptor.forClass(Interview.class);
+        verify(interviewRepository).save(interviewCaptor.capture());
+        Interview saved = interviewCaptor.getValue();
+        assertEquals(TranscriptionStatus.COMPLETED, saved.getTranscriptionStatus());
+        assertNull(saved.getTranscriptionText());
+        assertNotNull(saved.getUpdatedAt());
+    }
+
+    private Interview interview(Long id) {
+        Interview interview = new Interview();
+        interview.setId(id);
+        interview.setUserId(1L);
+        interview.setInterviewDate(LocalDate.of(2026, 3, 1));
+        return interview;
+    }
+}

--- a/backend/src/test/java/com/mindtrack/messaging/controller/WhatsAppWebhookControllerTest.java
+++ b/backend/src/test/java/com/mindtrack/messaging/controller/WhatsAppWebhookControllerTest.java
@@ -1,6 +1,7 @@
 package com.mindtrack.messaging.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mindtrack.messaging.config.MessagingProperties;
 import com.mindtrack.messaging.dto.WhatsAppWebhook;
 import com.mindtrack.messaging.service.MessagingService;
 import java.util.List;
@@ -13,9 +14,12 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -34,6 +38,9 @@ class WhatsAppWebhookControllerTest {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @Autowired
+    private MessagingProperties properties;
 
     @MockitoBean
     private MessagingService messagingService;
@@ -59,6 +66,7 @@ class WhatsAppWebhookControllerTest {
 
     @Test
     void shouldAcceptWhatsAppWebhookWithoutAuth() throws Exception {
+        properties.getWhatsapp().setAppSecret("");
         // WhatsApp webhooks are public endpoints — no JWT needed.
         // appSecret is blank so signature verification is skipped.
         WhatsAppWebhook.Change change = new WhatsAppWebhook.Change();
@@ -91,6 +99,7 @@ class WhatsAppWebhookControllerTest {
 
     @Test
     void shouldReturnBadRequestForInvalidJsonBody() throws Exception {
+        properties.getWhatsapp().setAppSecret("");
         // appSecret is blank so signature check is skipped; malformed JSON hits parse catch
         mockMvc.perform(post("/api/webhooks/whatsapp")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -100,6 +109,7 @@ class WhatsAppWebhookControllerTest {
 
     @Test
     void shouldReturnBadRequestWhenObjectFieldIsNotWhatsApp() throws Exception {
+        properties.getWhatsapp().setAppSecret("");
         WhatsAppWebhook.Change change = new WhatsAppWebhook.Change();
         change.setField("messages");
 
@@ -121,6 +131,7 @@ class WhatsAppWebhookControllerTest {
 
     @Test
     void shouldReturnBadRequestWhenEntryIsEmpty() throws Exception {
+        properties.getWhatsapp().setAppSecret("");
         WhatsAppWebhook webhook = new WhatsAppWebhook();
         webhook.setObject("whatsapp_business_account");
         webhook.setEntry(List.of());   // empty entry array
@@ -135,6 +146,7 @@ class WhatsAppWebhookControllerTest {
 
     @Test
     void shouldReturnBadRequestWhenEntryIsNull() throws Exception {
+        properties.getWhatsapp().setAppSecret("");
         // Explicitly construct JSON with null entry
         String body = "{\"object\":\"whatsapp_business_account\",\"entry\":null}";
 
@@ -148,6 +160,7 @@ class WhatsAppWebhookControllerTest {
 
     @Test
     void shouldSanitizeXssInMessageText() throws Exception {
+        properties.getWhatsapp().setAppSecret("");
         // Verifies that the endpoint accepts the request (returns 200) even with XSS-like input,
         // because sanitisation strips non-printable/special chars before delegating to the service.
         WhatsAppWebhook.Text text = new WhatsAppWebhook.Text();
@@ -181,5 +194,132 @@ class WhatsAppWebhookControllerTest {
 
         // Service is called — sanitisation happens inside the controller before the delegate call
         verify(messagingService).handleWhatsAppMessage(any(WhatsAppWebhook.class));
+    }
+
+    @Test
+    void shouldRejectWebhookWhenSignatureIsMissingOrInvalid() throws Exception {
+        properties.getWhatsapp().setAppSecret("app-secret");
+        String body = "{\"object\":\"whatsapp_business_account\",\"entry\":[]}";
+
+        mockMvc.perform(post("/api/webhooks/whatsapp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(post("/api/webhooks/whatsapp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-Hub-Signature-256", "sha256=invalid")
+                        .content(body))
+                .andExpect(status().isForbidden());
+
+        verify(messagingService, never()).handleWhatsAppMessage(any());
+    }
+
+    @Test
+    void shouldAcceptWebhookWithValidSignature() throws Exception {
+        properties.getWhatsapp().setAppSecret("app-secret");
+        reset(messagingService);
+        String body = objectMapper.writeValueAsString(validWebhook());
+        String signature = TestSignatures.sign(body, "app-secret");
+
+        mockMvc.perform(post("/api/webhooks/whatsapp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-Hub-Signature-256", signature)
+                        .content(body))
+                .andExpect(status().isOk());
+
+        verify(messagingService).handleWhatsAppMessage(any(WhatsAppWebhook.class));
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenEntryIdIsMissing() throws Exception {
+        properties.getWhatsapp().setAppSecret("");
+        WhatsAppWebhook webhook = validWebhook();
+        webhook.getEntry().getFirst().setId(" ");
+
+        mockMvc.perform(post("/api/webhooks/whatsapp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(webhook)))
+                .andExpect(status().isBadRequest());
+
+        verify(messagingService, never()).handleWhatsAppMessage(any());
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenChangesAreMissing() throws Exception {
+        properties.getWhatsapp().setAppSecret("");
+        WhatsAppWebhook webhook = validWebhook();
+        webhook.getEntry().getFirst().setChanges(List.of());
+
+        mockMvc.perform(post("/api/webhooks/whatsapp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(webhook)))
+                .andExpect(status().isBadRequest());
+
+        verify(messagingService, never()).handleWhatsAppMessage(any());
+    }
+
+    @Test
+    void shouldSanitizeContactsAndEmojiBeforeDelegating() throws Exception {
+        properties.getWhatsapp().setAppSecret("");
+        WhatsAppWebhook webhook = validWebhook();
+        WhatsAppWebhook.Contact contact = new WhatsAppWebhook.Contact();
+        contact.setWaId("+34 (600) 123-456");
+        webhook.getEntry().getFirst().getChanges().getFirst().getValue().setContacts(List.of(contact));
+        webhook.getEntry().getFirst().getChanges().getFirst().getValue().getMessages().getFirst().getText()
+                .setBody("Hello \uD83D\uDE0A 123");
+
+        mockMvc.perform(post("/api/webhooks/whatsapp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(webhook)))
+                .andExpect(status().isOk());
+
+        var captor = forClass(WhatsAppWebhook.class);
+        verify(messagingService).handleWhatsAppMessage(captor.capture());
+        WhatsAppWebhook delegated = captor.getValue();
+        assertEquals("34600123456", delegated.getEntry().getFirst().getChanges().getFirst().getValue()
+                .getContacts().getFirst().getWaId());
+        assertEquals("Hello  123", delegated.getEntry().getFirst().getChanges().getFirst().getValue()
+                .getMessages().getFirst().getText().getBody());
+    }
+
+    private WhatsAppWebhook validWebhook() {
+        WhatsAppWebhook.Text text = new WhatsAppWebhook.Text();
+        text.setBody("Hello");
+
+        WhatsAppWebhook.Message message = new WhatsAppWebhook.Message();
+        message.setFrom("15550001234");
+        message.setId("wamid.1");
+        message.setType("text");
+        message.setText(text);
+
+        WhatsAppWebhook.Value value = new WhatsAppWebhook.Value();
+        value.setMessages(List.of(message));
+
+        WhatsAppWebhook.Change change = new WhatsAppWebhook.Change();
+        change.setField("messages");
+        change.setValue(value);
+
+        WhatsAppWebhook.Entry entry = new WhatsAppWebhook.Entry();
+        entry.setId("123456789");
+        entry.setChanges(List.of(change));
+
+        WhatsAppWebhook webhook = new WhatsAppWebhook();
+        webhook.setObject("whatsapp_business_account");
+        webhook.setEntry(List.of(entry));
+        return webhook;
+    }
+
+    private static final class TestSignatures {
+        private TestSignatures() {
+        }
+
+        private static String sign(String body, String secret) throws Exception {
+            javax.crypto.Mac mac = javax.crypto.Mac.getInstance("HmacSHA256");
+            mac.init(new javax.crypto.spec.SecretKeySpec(
+                    secret.getBytes(java.nio.charset.StandardCharsets.UTF_8), "HmacSHA256"));
+            byte[] hash = mac.doFinal(body.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            return "sha256=" + java.util.HexFormat.of().formatHex(hash);
+        }
     }
 }

--- a/backend/src/test/java/com/mindtrack/profile/service/ProfileServiceTest.java
+++ b/backend/src/test/java/com/mindtrack/profile/service/ProfileServiceTest.java
@@ -15,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -125,6 +126,82 @@ class ProfileServiceTest {
         profileService.updateProfile(1L, request);
 
         verify(profileMapper).applyRequest(request, profile);
+    }
+
+    @Test
+    void shouldCompleteOnboardingForExistingProfile() {
+        UserProfile profile = createProfile();
+        when(profileRepository.findByUserId(1L)).thenReturn(Optional.of(profile));
+
+        profileService.completeOnboarding(1L);
+
+        assertTrue(profile.isOnboardingCompleted());
+        verify(profileRepository).save(profile);
+    }
+
+    @Test
+    void shouldCompleteSurveyForNewProfile() {
+        UserProfile createdProfile = new UserProfile();
+        createdProfile.setUserId(2L);
+
+        when(profileRepository.findByUserId(2L)).thenReturn(Optional.empty());
+        when(profileRepository.save(any(UserProfile.class))).thenReturn(createdProfile);
+
+        profileService.completeSurvey(2L);
+
+        ArgumentCaptor<UserProfile> captor = ArgumentCaptor.forClass(UserProfile.class);
+        verify(profileRepository, times(2)).save(captor.capture());
+        UserProfile savedProfile = captor.getAllValues().get(1);
+        assertTrue(savedProfile.isOnboardingCompleted());
+        assertTrue(savedProfile.isSurveyCompleted());
+    }
+
+    @Test
+    void shouldSkipOnboardingForExistingProfile() {
+        UserProfile profile = createProfile();
+        when(profileRepository.findByUserId(1L)).thenReturn(Optional.of(profile));
+
+        profileService.skipOnboarding(1L);
+
+        assertTrue(profile.isOnboardingCompleted());
+        verify(profileRepository).save(profile);
+    }
+
+    @Test
+    void shouldUpdateRolesForNewProfile() {
+        UserProfile createdProfile = new UserProfile();
+        createdProfile.setUserId(3L);
+
+        when(profileRepository.findByUserId(3L)).thenReturn(Optional.empty());
+        when(profileRepository.save(any(UserProfile.class))).thenReturn(createdProfile);
+
+        UserProfile updated = profileService.updateRoles(3L, true, false);
+
+        assertTrue(updated.isPatient());
+        assertEquals(false, updated.isTherapist());
+        verify(profileRepository, times(2)).save(any(UserProfile.class));
+    }
+
+    @Test
+    void shouldRecordAiConsent() {
+        UserProfile profile = createProfile();
+        when(profileRepository.findByUserId(1L)).thenReturn(Optional.of(profile));
+
+        profileService.giveAiConsent(1L);
+
+        assertTrue(profile.isAiConsentGiven());
+        verify(profileRepository).save(profile);
+    }
+
+    @Test
+    void shouldReturnExistingProfileFromGetOrCreateProfile() {
+        UserProfile profile = createProfile();
+        when(profileRepository.findByUserId(1L)).thenReturn(Optional.of(profile));
+
+        UserProfile result = profileService.getOrCreateProfile(1L);
+
+        assertEquals(profile, result);
+        verify(profileRepository).findByUserId(1L);
     }
 
     private UserProfile createProfile() {

--- a/frontend/src/__tests__/App.test.ts
+++ b/frontend/src/__tests__/App.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import App from '../App.vue'
+
+const routeState = vi.hoisted(() => ({
+  meta: { requiresAuth: false },
+}))
+
+const authState = vi.hoisted(() => ({
+  isAuthenticated: false,
+  user: null as null | Record<string, unknown>,
+  fetchCurrentUser: vi.fn(),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => routeState,
+  RouterView: { template: '<div class="router-view-stub" />' },
+}))
+
+vi.mock('@/components/layout/AppNavbar.vue', () => ({
+  default: { template: '<nav class="app-navbar-stub" />' },
+}))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => authState,
+}))
+
+describe('App', () => {
+  beforeEach(() => {
+    routeState.meta = { requiresAuth: false }
+    authState.isAuthenticated = false
+    authState.user = null
+    authState.fetchCurrentUser.mockReset().mockResolvedValue(undefined)
+  })
+
+  it('hides the navbar on public routes', () => {
+    const wrapper = mount(App)
+
+    expect(wrapper.find('.app-navbar-stub').exists()).toBe(false)
+    expect(wrapper.find('main').classes()).not.toContain('has-navbar')
+  })
+
+  it('shows the navbar on authenticated routes', () => {
+    routeState.meta = { requiresAuth: true }
+    const wrapper = mount(App)
+
+    expect(wrapper.find('.app-navbar-stub').exists()).toBe(true)
+    expect(wrapper.find('main').classes()).toContain('has-navbar')
+  })
+
+  it('fetches the current user on mount when auth exists without a user object', async () => {
+    routeState.meta = { requiresAuth: true }
+    authState.isAuthenticated = true
+    authState.user = null
+
+    mount(App)
+    await flushPromises()
+
+    expect(authState.fetchCurrentUser).toHaveBeenCalled()
+  })
+
+  it('does not refetch the user when already loaded', async () => {
+    authState.isAuthenticated = true
+    authState.user = { id: '1' }
+
+    mount(App)
+    await flushPromises()
+
+    expect(authState.fetchCurrentUser).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/__tests__/main.test.ts
+++ b/frontend/src/__tests__/main.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const appUse = vi.fn()
+const appMount = vi.fn()
+const createAppMock = vi.fn(() => ({
+  use: appUse,
+  mount: appMount,
+}))
+const createPiniaMock = vi.fn(() => ({ pinia: true }))
+const sentryInit = vi.fn()
+const browserTracingIntegration = vi.fn(() => ({ name: 'browserTracing' }))
+const createGtagMock = vi.fn((config) => ({ plugin: 'gtag', config }))
+const routerMock = { name: 'router' }
+
+vi.mock('vue', () => ({
+  createApp: createAppMock,
+}))
+
+vi.mock('pinia', () => ({
+  createPinia: createPiniaMock,
+}))
+
+vi.mock('@sentry/vue', () => ({
+  init: sentryInit,
+  browserTracingIntegration,
+}))
+
+vi.mock('vue-gtag', () => ({
+  createGtag: createGtagMock,
+}))
+
+vi.mock('../App.vue', () => ({
+  default: { name: 'AppStub' },
+}))
+
+vi.mock('../router', () => ({
+  default: routerMock,
+}))
+
+describe('main bootstrap', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.unstubAllEnvs()
+    createAppMock.mockClear()
+    createPiniaMock.mockClear()
+    appUse.mockClear()
+    appMount.mockClear()
+    sentryInit.mockClear()
+    browserTracingIntegration.mockClear()
+    createGtagMock.mockClear()
+  })
+
+  it('boots the app without Sentry or Google Analytics by default', async () => {
+    await import('../main')
+
+    expect(createAppMock).toHaveBeenCalled()
+    expect(appUse).toHaveBeenCalledWith({ pinia: true })
+    expect(appUse).toHaveBeenCalledWith(routerMock)
+    expect(appMount).toHaveBeenCalledWith('#app')
+    expect(sentryInit).not.toHaveBeenCalled()
+    expect(createGtagMock).not.toHaveBeenCalled()
+  })
+
+  it('initializes Sentry and Google Analytics when env vars are set', async () => {
+    vi.stubEnv('VITE_SENTRY_DSN', 'https://dsn.example')
+    vi.stubEnv('VITE_SENTRY_RELEASE', 'frontend@1.2.3')
+    vi.stubEnv('VITE_SENTRY_TRACES_SAMPLE_RATE', '0.25')
+    vi.stubEnv('VITE_APP_ENV', 'production')
+    vi.stubEnv('VITE_GA_MEASUREMENT_ID', 'G-12345')
+
+    await import('../main')
+
+    expect(browserTracingIntegration).toHaveBeenCalledWith({ router: routerMock })
+    expect(sentryInit).toHaveBeenCalledTimes(1)
+    const sentryConfig = sentryInit.mock.calls[0][0] as {
+      beforeBreadcrumb: (breadcrumb: {
+        category: string
+        data?: { to?: string; from?: string }
+      }) => { data?: { to?: string; from?: string } }
+    }
+    const breadcrumb = sentryConfig.beforeBreadcrumb({
+      category: 'navigation',
+      data: { to: '/goals/12', from: '/journal/9' },
+    })
+    expect(breadcrumb.data?.to).toBe('/goals/[id]')
+    expect(breadcrumb.data?.from).toBe('/journal/[id]')
+
+    expect(createGtagMock).toHaveBeenCalledTimes(1)
+    const gtagConfig = createGtagMock.mock.calls[0][0] as {
+      pageTracker: {
+        template: (to: { name?: string; path: string; matched: Array<{ path: string }> }) => unknown
+      }
+    }
+    expect(
+      gtagConfig.pageTracker.template({
+        name: 'goal-detail',
+        path: '/goals/42',
+        matched: [{ path: '/goals/:id' }],
+      }),
+    ).toEqual({
+      page_title: 'goal-detail',
+      page_path: '/goals/:id',
+    })
+  })
+})

--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+let successHandler: (response: unknown) => unknown
+let errorHandler: (error: { response?: { status?: number } }) => unknown
+
+vi.mock('axios', () => ({
+  default: {
+    create: vi.fn(() => ({
+      interceptors: {
+        response: {
+          use: (success: typeof successHandler, error: typeof errorHandler) => {
+            successHandler = success
+            errorHandler = error
+          },
+        },
+      },
+    })),
+  },
+}))
+
+describe('api client', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    Object.defineProperty(globalThis, 'location', {
+      value: { href: 'http://localhost/' },
+      configurable: true,
+    })
+  })
+
+  it('returns successful responses unchanged', async () => {
+    await import('../client')
+    const response = { data: { ok: true } }
+
+    expect(successHandler(response)).toBe(response)
+  })
+
+  it('redirects to login on unauthorized errors', async () => {
+    await import('../client')
+    const error = { response: { status: 401 } }
+
+    expect(() => errorHandler(error)).toThrow()
+    expect(globalThis.location.href).toBe('/login')
+  })
+
+  it('does not redirect on non-401 errors', async () => {
+    await import('../client')
+    const error = { response: { status: 500 } }
+
+    expect(() => errorHandler(error)).toThrow()
+    expect(globalThis.location.href).toBe('http://localhost/')
+  })
+})

--- a/frontend/src/components/charts/__tests__/Charts.test.ts
+++ b/frontend/src/components/charts/__tests__/Charts.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ActivityCompletionChart from '../ActivityCompletionChart.vue'
+import GoalProgressChart from '../GoalProgressChart.vue'
+import MoodTrendChart from '../MoodTrendChart.vue'
+
+const barProps = vi.fn()
+const doughnutProps = vi.fn()
+const lineProps = vi.fn()
+
+vi.mock('vue-chartjs', () => ({
+  Bar: {
+    props: ['data', 'options'],
+    template: '<div class="bar-chart" />',
+    setup(props: unknown) {
+      barProps(props)
+    },
+  },
+  Doughnut: {
+    props: ['data', 'options'],
+    template: '<div class="doughnut-chart" />',
+    setup(props: unknown) {
+      doughnutProps(props)
+    },
+  },
+  Line: {
+    props: ['data', 'options'],
+    template: '<div class="line-chart" />',
+    setup(props: unknown) {
+      lineProps(props)
+    },
+  },
+}))
+
+describe('Chart components', () => {
+  it('renders the activity completion fallback and chart data', async () => {
+    const emptyWrapper = mount(ActivityCompletionChart, { props: { data: [] } })
+    expect(emptyWrapper.text()).toContain('No activity data for this period')
+
+    mount(ActivityCompletionChart, {
+      props: {
+        data: [
+          { activityType: 'HOMEWORK_TASK', completionRate: 75, completedLogs: 3, totalLogs: 4 },
+        ],
+      },
+    })
+
+    const props = barProps.mock.calls.at(-1)?.[0] as {
+      data: { labels: string[]; datasets: Array<{ data: number[] }> }
+      options: {
+        plugins: {
+          tooltip: { callbacks: { afterLabel: (context: { dataIndex: number }) => string } }
+        }
+      }
+    }
+    expect(props.data.labels).toEqual(['Homework Task'])
+    expect(props.data.datasets[0].data).toEqual([75])
+    expect(props.options.plugins.tooltip.callbacks.afterLabel({ dataIndex: 0 })).toBe(
+      '3/4 completed',
+    )
+  })
+
+  it('renders the goal progress fallback and chart labels', () => {
+    const emptyWrapper = mount(GoalProgressChart, { props: { data: [] } })
+    expect(emptyWrapper.text()).toContain('No goals yet')
+
+    mount(GoalProgressChart, {
+      props: {
+        data: [{ status: 'IN_PROGRESS', count: 2 }],
+      },
+    })
+
+    const props = doughnutProps.mock.calls.at(-1)?.[0] as {
+      data: { labels: string[]; datasets: Array<{ data: number[]; backgroundColor: string[] }> }
+    }
+    expect(props.data.labels).toEqual(['In Progress'])
+    expect(props.data.datasets[0].data).toEqual([2])
+    expect(props.data.datasets[0].backgroundColor).toEqual(['#6366f1'])
+  })
+
+  it('renders the mood trend fallback and formats tooltip labels', () => {
+    const emptyWrapper = mount(MoodTrendChart, { props: { data: [] } })
+    expect(emptyWrapper.text()).toContain('No mood data for this period')
+
+    mount(MoodTrendChart, {
+      props: {
+        data: [
+          { date: '2025-01-10', averageMood: 6.5, entryCount: 1 },
+          { date: '2025-01-11', averageMood: 7, entryCount: 3 },
+        ],
+      },
+    })
+
+    const props = lineProps.mock.calls.at(-1)?.[0] as {
+      data: { labels: string[]; datasets: Array<{ data: number[] }> }
+      options: {
+        plugins: {
+          tooltip: { callbacks: { afterLabel: (context: { dataIndex: number }) => string } }
+        }
+      }
+    }
+    expect(props.data.labels).toEqual(['Jan 10', 'Jan 11'])
+    expect(props.data.datasets[0].data).toEqual([6.5, 7])
+    expect(props.options.plugins.tooltip.callbacks.afterLabel({ dataIndex: 0 })).toBe('1 entry')
+    expect(props.options.plugins.tooltip.callbacks.afterLabel({ dataIndex: 1 })).toBe('3 entries')
+  })
+})

--- a/frontend/src/components/interview/__tests__/AudioSection.test.ts
+++ b/frontend/src/components/interview/__tests__/AudioSection.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import AudioSection from '../AudioSection.vue'
 
@@ -24,10 +24,17 @@ function mountComponent(props = defaultProps) {
   })
 }
 
+async function settle() {
+  await vi.dynamicImportSettled()
+  await flushPromises()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
 describe('AudioSection', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
+    vi.useRealTimers()
   })
 
   it('shows upload area when no audio exists', () => {
@@ -47,11 +54,7 @@ describe('AudioSection', () => {
     })
 
     const wrapper = mountComponent({ interviewId: 1, hasAudio: true })
-    await vi.dynamicImportSettled()
-    await wrapper.vm.$nextTick()
-    // Wait for onMounted async
-    await new Promise((resolve) => setTimeout(resolve, 0))
-    await wrapper.vm.$nextTick()
+    await settle()
 
     expect(mockGet).toHaveBeenCalledWith('/interviews/1/audio')
     expect(wrapper.find('audio').exists()).toBe(true)
@@ -98,8 +101,7 @@ describe('AudioSection', () => {
     Object.defineProperty(fileInput.element, 'files', { value: [file] })
     await fileInput.trigger('change')
 
-    await vi.dynamicImportSettled()
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    await settle()
 
     expect(mockPost).toHaveBeenCalledWith(
       '/interviews/1/audio',
@@ -120,9 +122,7 @@ describe('AudioSection', () => {
     })
 
     const wrapper = mountComponent({ interviewId: 1, hasAudio: true })
-    await vi.dynamicImportSettled()
-    await new Promise((resolve) => setTimeout(resolve, 0))
-    await wrapper.vm.$nextTick()
+    await settle()
 
     expect(wrapper.text()).toContain('Hello world transcription')
   })
@@ -131,5 +131,175 @@ describe('AudioSection', () => {
     const wrapper = mountComponent()
     expect(wrapper.text()).toContain('MP3, WAV, M4A, FLAC, OGG, WebM')
     expect(wrapper.text()).toContain('50 MB')
+  })
+
+  it('shows pending transcription when audio is still processing', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        audioUrl: 'http://example.com/audio.mp3',
+        transcriptionText: null,
+        audioExpiresAt: '2025-02-01T00:00:00',
+        transcriptionStatus: 'IN_PROGRESS',
+      },
+    })
+
+    const wrapper = mountComponent({ interviewId: 1, hasAudio: true })
+    await settle()
+
+    expect(wrapper.text()).toContain('Transcribing audio...')
+  })
+
+  it('deletes existing audio', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        audioUrl: 'http://example.com/audio.mp3',
+        transcriptionText: null,
+        audioExpiresAt: '2025-02-01T00:00:00',
+        transcriptionStatus: 'COMPLETED',
+      },
+    })
+
+    const wrapper = mountComponent({ interviewId: 1, hasAudio: true })
+    await settle()
+
+    await wrapper.find('.btn-delete').trigger('click')
+    await settle()
+
+    expect(mockDelete).toHaveBeenCalledWith('/interviews/1/audio')
+  })
+
+  it('shows an upload error when upload fails', async () => {
+    mockPost.mockRejectedValue(new Error('upload failed'))
+
+    const wrapper = mountComponent()
+    const fileInput = wrapper.find('[data-testid="audio-file-input"]')
+    const file = new File(['audio-content'], 'recording.mp3', { type: 'audio/mpeg' })
+
+    Object.defineProperty(fileInput.element, 'files', { value: [file] })
+    await fileInput.trigger('change')
+    await settle()
+
+    expect(wrapper.text()).toContain('Upload failed. Please try again.')
+  })
+
+  it('dismisses validation errors', async () => {
+    const wrapper = mountComponent()
+    const fileInput = wrapper.find('[data-testid="audio-file-input"]')
+    const file = new File(['content'], 'document.pdf', { type: 'application/pdf' })
+
+    Object.defineProperty(fileInput.element, 'files', { value: [file] })
+    await fileInput.trigger('change')
+    expect(wrapper.find('.audio-error').exists()).toBe(true)
+
+    await wrapper.find('.error-dismiss').trigger('click')
+    expect(wrapper.find('.audio-error').exists()).toBe(false)
+  })
+
+  it('shows an error when microphone access is denied', async () => {
+    Object.defineProperty(globalThis.navigator, 'mediaDevices', {
+      value: {
+        getUserMedia: vi.fn().mockRejectedValue(new Error('denied')),
+      },
+      configurable: true,
+    })
+
+    const wrapper = mountComponent()
+    await wrapper.find('.btn-record').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Microphone access denied.')
+  })
+
+  it('records audio, uploads it, and shows transcription progress', async () => {
+    vi.useFakeTimers()
+
+    const stopTrack = vi.fn()
+    Object.defineProperty(globalThis.navigator, 'mediaDevices', {
+      value: {
+        getUserMedia: vi.fn().mockResolvedValue({
+          getTracks: () => [{ stop: stopTrack }],
+        }),
+      },
+      configurable: true,
+    })
+
+    class MediaRecorderMock {
+      ondataavailable: ((event: { data: Blob }) => void) | null = null
+      onstop: (() => void) | null = null
+
+      constructor() {}
+
+      start() {}
+
+      stop() {
+        this.ondataavailable?.({ data: new Blob(['chunk'], { type: 'audio/webm' }) })
+        this.onstop?.()
+      }
+    }
+
+    Object.defineProperty(globalThis, 'MediaRecorder', {
+      value: MediaRecorderMock,
+      configurable: true,
+    })
+
+    mockPost.mockResolvedValue({
+      data: {
+        audioUrl: 'http://example.com/recording.webm',
+        transcriptionText: null,
+        audioExpiresAt: '2025-02-01T00:00:00',
+      },
+    })
+
+    const wrapper = mountComponent()
+    await wrapper.find('.btn-record').trigger('click')
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(2000)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('00:02')
+
+    await wrapper.find('.btn-stop').trigger('click')
+    await flushPromises()
+
+    expect(stopTrack).toHaveBeenCalled()
+    expect(mockPost).toHaveBeenCalledWith(
+      '/interviews/1/audio',
+      expect.any(FormData),
+      expect.objectContaining({
+        headers: { 'Content-Type': 'multipart/form-data' },
+      }),
+    )
+    expect(wrapper.text()).toContain('Transcribing')
+  })
+
+  it('shows a slow-transcription warning after repeated pending polls', async () => {
+    vi.useFakeTimers()
+    mockGet
+      .mockResolvedValueOnce({
+        data: {
+          audioUrl: 'http://example.com/audio.mp3',
+          transcriptionText: null,
+          audioExpiresAt: '2025-02-01T00:00:00',
+          transcriptionStatus: 'IN_PROGRESS',
+        },
+      })
+      .mockResolvedValue({
+        data: {
+          audioUrl: 'http://example.com/audio.mp3',
+          transcriptionText: null,
+          audioExpiresAt: '2025-02-01T00:00:00',
+          transcriptionStatus: 'IN_PROGRESS',
+        },
+      })
+
+    const wrapper = mountComponent({ interviewId: 1, hasAudio: true })
+    await flushPromises()
+
+    for (let i = 0; i < 4; i++) {
+      await vi.advanceTimersByTimeAsync(10000)
+      await flushPromises()
+    }
+
+    expect(wrapper.text()).toContain('Transcription taking longer than expected')
   })
 })

--- a/frontend/src/components/layout/__tests__/AppNavbar.test.ts
+++ b/frontend/src/components/layout/__tests__/AppNavbar.test.ts
@@ -30,6 +30,8 @@ const router = createRouter({
     { path: '/interviews', component: { template: '<div>Interviews</div>' } },
     { path: '/chat', component: { template: '<div>Chat</div>' } },
     { path: '/profile', component: { template: '<div>Profile</div>' } },
+    { path: '/admin', component: { template: '<div>Admin</div>' } },
+    { path: '/therapist', component: { template: '<div>Therapist</div>' } },
     { path: '/', component: { template: '<div>Home</div>' } },
   ],
 })
@@ -109,5 +111,23 @@ describe('AppNavbar', () => {
 
     await wrapper.find('.btn-logout').trigger('click')
     expect(auth.isAuthenticated).toBe(false)
+  })
+
+  it('shows admin and therapist links for elevated users', () => {
+    const auth = useAuthStore()
+    auth.setUser({
+      id: '1',
+      email: 'admin@test.com',
+      name: 'Admin Therapist',
+      role: 'ADMIN',
+      isPatient: true,
+      isTherapist: true,
+    })
+
+    const wrapper = mountNavbar()
+    const linkTexts = wrapper.findAll('.nav-link').map((link) => link.text())
+
+    expect(linkTexts).toContain('Admin')
+    expect(linkTexts).toContain('Patients')
   })
 })

--- a/frontend/src/components/tutorial/__tests__/TutorialOverlay.test.ts
+++ b/frontend/src/components/tutorial/__tests__/TutorialOverlay.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import TutorialOverlay from '../TutorialOverlay.vue'
 import { useTutorial } from '@/composables/useTutorial'
@@ -90,5 +90,29 @@ describe('TutorialOverlay', () => {
     await wrapper.vm.$nextTick()
 
     expect(wrapper.find('[data-testid="tutorial-next"]').text()).toBe('Get Started')
+  })
+
+  it('skips the tutorial when the backdrop is clicked', async () => {
+    const { start, isActive } = useTutorial()
+    start()
+    const wrapper = mountOverlay()
+
+    await wrapper.find('.tutorial-backdrop').trigger('click')
+    await flushPromises()
+
+    expect(isActive.value).toBe(false)
+  })
+
+  it('centers the tooltip when the target element is missing', async () => {
+    const { start } = useTutorial()
+    start()
+    const wrapper = mountOverlay()
+    await flushPromises()
+    await wrapper.find('[data-testid="tutorial-next"]').trigger('click')
+    await flushPromises()
+
+    const element = wrapper.find('[data-testid="tutorial-tooltip"]').element as HTMLElement
+    expect(element.style.top).toBe('50%')
+    expect(element.style.left).toBe('50%')
   })
 })

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const postMock = vi.fn()
+const apiCallMock = vi.fn()
+const pushMock = vi.fn()
+const logoutMock = vi.fn()
+const authStore = { logout: logoutMock }
+let successHandler: (response: unknown) => unknown
+let errorHandler: (error: {
+  config: { _retry?: boolean; headers: Record<string, string> }
+  response?: { status?: number }
+}) => Promise<unknown>
+
+vi.mock('axios', () => ({
+  default: {
+    create: vi.fn(() => {
+      const instance = Object.assign(apiCallMock, {
+        post: postMock,
+        interceptors: {
+          response: {
+            use: (success: typeof successHandler, error: typeof errorHandler) => {
+              successHandler = success
+              errorHandler = error
+            },
+          },
+        },
+      })
+      return instance
+    }),
+  },
+}))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => authStore,
+}))
+
+vi.mock('@/router', () => ({
+  default: {
+    push: pushMock,
+  },
+}))
+
+describe('api service', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: {
+        getItem: vi.fn(() => null),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+      },
+      configurable: true,
+    })
+  })
+
+  it('returns successful responses unchanged', async () => {
+    const { default: api } = await import('../api')
+    const response = { data: { ok: true } }
+
+    expect(successHandler(response)).toBe(response)
+    expect(api).toBeDefined()
+  })
+
+  it('refreshes tokens and retries the original request on 401', async () => {
+    postMock.mockResolvedValueOnce({ data: { token: 'jwt-new', refreshToken: 'refresh-new' } })
+    apiCallMock.mockResolvedValueOnce({ data: { retried: true } })
+    const storage = globalThis.localStorage as unknown as {
+      getItem: ReturnType<typeof vi.fn>
+      setItem: ReturnType<typeof vi.fn>
+    }
+    storage.getItem.mockReturnValue('refresh-old')
+
+    await import('../api')
+
+    const originalRequest = { _retry: false, headers: {} as Record<string, string> }
+    const result = await errorHandler({
+      config: originalRequest,
+      response: { status: 401 },
+    })
+
+    expect(postMock).toHaveBeenCalledWith('/auth/refresh', { refreshToken: 'refresh-old' })
+    expect(storage.setItem).toHaveBeenCalledWith('refreshToken', 'refresh-new')
+    expect(originalRequest.headers.Authorization).toBe('Bearer jwt-new')
+    expect(result).toEqual({ data: { retried: true } })
+  })
+
+  it('logs out and redirects when refresh fails', async () => {
+    postMock.mockRejectedValueOnce(new Error('refresh failed'))
+    const storage = globalThis.localStorage as unknown as {
+      getItem: ReturnType<typeof vi.fn>
+      removeItem: ReturnType<typeof vi.fn>
+    }
+    storage.getItem.mockReturnValue('refresh-old')
+
+    await import('../api')
+
+    let thrown: unknown
+    try {
+      await errorHandler({
+        config: { _retry: false, headers: {} },
+        response: { status: 401 },
+      })
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toEqual(
+      expect.objectContaining({
+        response: { status: 401 },
+      }),
+    )
+    expect(storage.removeItem).toHaveBeenCalledWith('refreshToken')
+    expect(logoutMock).toHaveBeenCalled()
+    expect(pushMock).toHaveBeenCalledWith('/')
+  })
+})

--- a/frontend/src/stores/__tests__/activities.test.ts
+++ b/frontend/src/stores/__tests__/activities.test.ts
@@ -119,6 +119,24 @@ describe('useActivitiesStore', () => {
     expect(store.activities[0].active).toBe(false)
   })
 
+  it('updates an existing activity', async () => {
+    api.get.mockResolvedValue({ data: mockActivities })
+    api.put.mockResolvedValue({ data: { ...mockActivities[0], name: 'Updated jog' } })
+    const store = useActivitiesStore()
+    await store.fetchActivities()
+
+    await store.updateActivity(1, {
+      type: 'EXERCISE',
+      name: 'Updated jog',
+      description: 'Updated',
+      frequency: 'Daily',
+      linkedInterviewId: null,
+    })
+
+    expect(api.put).toHaveBeenCalledWith('/activities/1', expect.any(Object))
+    expect(store.activities[0].name).toBe('Updated jog')
+  })
+
   it('deletes activity', async () => {
     api.get.mockResolvedValue({ data: mockActivities })
     api.delete.mockResolvedValue({})
@@ -194,6 +212,40 @@ describe('useActivitiesStore', () => {
     await expect(store.fetchActivities()).rejects.toThrow('Network error')
 
     expect(store.error).toBe('Failed to load activities')
+  })
+
+  it('sets error on checklist failure', async () => {
+    api.get.mockRejectedValue(new Error('Checklist error'))
+    const store = useActivitiesStore()
+
+    await expect(store.fetchChecklist('2025-01-15')).rejects.toThrow('Checklist error')
+    expect(store.error).toBe('Failed to load checklist')
+  })
+
+  it('sets error on activity logging failure', async () => {
+    api.post.mockRejectedValue(new Error('Log error'))
+    const store = useActivitiesStore()
+
+    await expect(
+      store.logActivity(1, {
+        logDate: '2025-01-15',
+        completed: true,
+        notes: '',
+        moodRating: null,
+      }),
+    ).rejects.toThrow('Log error')
+
+    expect(store.error).toBe('Failed to log activity')
+  })
+
+  it('sets error when deleting an activity fails', async () => {
+    api.delete.mockRejectedValue(new Error('Delete error'))
+    const store = useActivitiesStore()
+
+    await expect(store.deleteActivity(1)).rejects.toThrow('Delete error')
+
+    expect(store.error).toBe('Failed to delete activity')
+    expect(store.loading).toBe(false)
   })
 
   it('clears error', () => {

--- a/frontend/src/stores/__tests__/interviews.test.ts
+++ b/frontend/src/stores/__tests__/interviews.test.ts
@@ -169,4 +169,80 @@ describe('useInterviewsStore', () => {
 
     expect(store.error).toBeNull()
   })
+
+  it('uploads audio and updates the current interview', async () => {
+    api.post.mockResolvedValue({
+      data: {
+        audioUrl: 'https://example.com/audio.mp3',
+        transcriptionText: 'Transcript',
+        audioExpiresAt: '2025-02-22T10:00:00',
+      },
+    })
+    const store = useInterviewsStore()
+    store.currentInterview = {
+      ...mockInterviews[1],
+      id: 2,
+      hasAudio: false,
+      transcriptionText: null,
+    }
+
+    await store.uploadAudio(2, new File(['audio'], 'clip.mp3', { type: 'audio/mpeg' }))
+
+    expect(api.post).toHaveBeenCalledWith(
+      '/interviews/2/audio',
+      expect.any(FormData),
+      expect.objectContaining({
+        headers: { 'Content-Type': 'multipart/form-data' },
+      }),
+    )
+    expect(store.currentInterview?.hasAudio).toBe(true)
+    expect(store.currentInterview?.transcriptionText).toBe('Transcript')
+  })
+
+  it('returns audio metadata', async () => {
+    api.get.mockResolvedValueOnce({
+      data: {
+        audioUrl: 'https://example.com/audio.mp3',
+        transcriptionText: null,
+        audioExpiresAt: '2025-02-22T10:00:00',
+      },
+    })
+    const store = useInterviewsStore()
+
+    await expect(store.getAudioUrl(2)).resolves.toEqual({
+      audioUrl: 'https://example.com/audio.mp3',
+      transcriptionText: null,
+      audioExpiresAt: '2025-02-22T10:00:00',
+    })
+  })
+
+  it('deletes audio and clears interview flags', async () => {
+    api.delete.mockResolvedValue({})
+    const store = useInterviewsStore()
+    store.currentInterview = {
+      ...mockInterviews[1],
+      id: 2,
+      hasAudio: true,
+      transcriptionText: 'Transcript',
+      audioExpiresAt: '2025-02-22T10:00:00',
+    }
+
+    await store.deleteAudio(2)
+
+    expect(api.delete).toHaveBeenCalledWith('/interviews/2/audio')
+    expect(store.currentInterview?.hasAudio).toBe(false)
+    expect(store.currentInterview?.transcriptionText).toBeNull()
+    expect(store.currentInterview?.audioExpiresAt).toBeNull()
+  })
+
+  it('sets errors for single interview and audio failures', async () => {
+    const store = useInterviewsStore()
+    api.get.mockRejectedValueOnce(new Error('Interview error'))
+    await expect(store.fetchInterview(9)).rejects.toThrow('Interview error')
+    expect(store.error).toBe('Failed to load interview')
+
+    api.get.mockRejectedValueOnce(new Error('Audio error'))
+    await expect(store.getAudioUrl(9)).rejects.toThrow('Audio error')
+    expect(store.error).toBe('Failed to load audio')
+  })
 })

--- a/frontend/src/stores/__tests__/profile.test.ts
+++ b/frontend/src/stores/__tests__/profile.test.ts
@@ -216,4 +216,66 @@ describe('useProfileStore', () => {
       expect(store.saving).toBe(false)
     })
   })
+
+  describe('survey flow', () => {
+    it('submits survey and marks onboarding complete', async () => {
+      api.post.mockResolvedValueOnce({})
+      const store = useProfileStore()
+      store.profile = { ...mockProfile, surveyCompleted: false, onboardingCompleted: false }
+
+      await store.submitSurvey({
+        moodBaseline: 6,
+        anxietyLevel: 4,
+        sleepQuality: 7,
+        lifeAreas: ['work'],
+      })
+
+      expect(api.post).toHaveBeenCalledWith('/onboarding/survey', {
+        moodBaseline: 6,
+        anxietyLevel: 4,
+        sleepQuality: 7,
+        lifeAreas: ['work'],
+      })
+      expect(store.profile?.surveyCompleted).toBe(true)
+      expect(store.profile?.onboardingCompleted).toBe(true)
+    })
+
+    it('skips survey and marks onboarding complete', async () => {
+      api.post.mockResolvedValueOnce({})
+      const store = useProfileStore()
+      store.profile = { ...mockProfile, onboardingCompleted: false }
+
+      await store.skipSurvey()
+
+      expect(api.post).toHaveBeenCalledWith('/onboarding/skip')
+      expect(store.profile?.onboardingCompleted).toBe(true)
+    })
+
+    it('sets an error when survey submission fails', async () => {
+      api.post.mockRejectedValueOnce(new Error('Survey error'))
+      const store = useProfileStore()
+
+      await expect(
+        store.submitSurvey({
+          moodBaseline: 6,
+          anxietyLevel: 4,
+          sleepQuality: 7,
+          lifeAreas: ['work'],
+        }),
+      ).rejects.toThrow()
+
+      expect(store.error).toBe('Failed to submit survey')
+      expect(store.saving).toBe(false)
+    })
+
+    it('sets an error when skipping survey fails', async () => {
+      api.post.mockRejectedValueOnce(new Error('Skip error'))
+      const store = useProfileStore()
+
+      await expect(store.skipSurvey()).rejects.toThrow()
+
+      expect(store.error).toBe('Failed to skip survey')
+      expect(store.saving).toBe(false)
+    })
+  })
 })

--- a/frontend/src/views/__tests__/AdminView.test.ts
+++ b/frontend/src/views/__tests__/AdminView.test.ts
@@ -231,4 +231,114 @@ describe('AdminView', () => {
     expect(wrapper.find('.no-permissions').exists()).toBe(true)
     expect(wrapper.find('.no-permissions').text()).toContain('No permissions assigned')
   })
+
+  it('changes a user role from the table', async () => {
+    mockGet.mockResolvedValueOnce({ data: sampleUsers })
+    mockPatch.mockResolvedValueOnce({
+      data: { ...sampleUsers.content[1], role: 'THERAPIST' },
+    })
+    const wrapper = mount(AdminView)
+    await flushPromises()
+
+    await wrapper.findAll('.role-select')[1].setValue('THERAPIST')
+    await flushPromises()
+
+    expect(mockPatch).toHaveBeenCalledWith('/admin/users/2/role', { role: 'THERAPIST' })
+    expect(wrapper.findAll('.role-select')[1].element.value).toBe('THERAPIST')
+  })
+
+  it('toggles a user enabled state', async () => {
+    mockGet.mockResolvedValueOnce({ data: sampleUsers })
+    mockPatch.mockResolvedValueOnce({
+      data: { ...sampleUsers.content[0], enabled: false },
+    })
+    const wrapper = mount(AdminView)
+    await flushPromises()
+
+    await wrapper.findAll('.users-table tbody .btn')[0].trigger('click')
+    await flushPromises()
+
+    expect(mockPatch).toHaveBeenCalledWith('/admin/users/1/enabled', { enabled: false })
+    expect(wrapper.findAll('.status-badge')[0].text()).toBe('Disabled')
+  })
+
+  it('dismisses the store error message', async () => {
+    mockGet.mockRejectedValueOnce(new Error('Network error'))
+    const wrapper = mount(AdminView)
+    await flushPromises()
+
+    await wrapper.find('.error-message .btn').trigger('click')
+
+    expect(wrapper.find('.error-message').exists()).toBe(false)
+  })
+
+  it('edits and saves role permissions', async () => {
+    mockGet.mockResolvedValueOnce({ data: sampleUsers })
+    mockGet.mockResolvedValueOnce({ data: sampleRoles })
+    mockGet.mockResolvedValueOnce({ data: samplePermissions })
+    mockPut.mockResolvedValueOnce({
+      data: {
+        ...sampleRoles[0],
+        permissions: samplePermissions,
+      },
+    })
+
+    const wrapper = mount(AdminView)
+    await flushPromises()
+    await wrapper.findAll('.tab')[1].trigger('click')
+    await flushPromises()
+
+    await wrapper.find('.role-card .btn-secondary').trigger('click')
+    const checkboxes = wrapper.findAll('.permission-checkbox input')
+    await checkboxes[1].setValue(true)
+    await wrapper.find('.edit-actions .btn-primary').trigger('click')
+    await flushPromises()
+
+    expect(mockPut).toHaveBeenCalledWith('/admin/roles/1/permissions', { permissionIds: [1, 2] })
+    expect(wrapper.text()).toContain('2 permissions')
+  })
+
+  it('cancels role permission editing', async () => {
+    mockGet.mockResolvedValueOnce({ data: sampleUsers })
+    mockGet.mockResolvedValueOnce({ data: sampleRoles })
+    mockGet.mockResolvedValueOnce({ data: samplePermissions })
+    const wrapper = mount(AdminView)
+    await flushPromises()
+    await wrapper.findAll('.tab')[1].trigger('click')
+    await flushPromises()
+
+    await wrapper.find('.role-card .btn-secondary').trigger('click')
+    expect(wrapper.find('.permissions-edit').exists()).toBe(true)
+
+    await wrapper.find('.edit-actions .btn-secondary').trigger('click')
+    expect(wrapper.find('.permissions-edit').exists()).toBe(false)
+  })
+
+  it('loads another page of users from pagination', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        ...sampleUsers,
+        totalPages: 2,
+        size: 1,
+      },
+    })
+    mockGet.mockResolvedValueOnce({
+      data: {
+        ...sampleUsers,
+        content: [sampleUsers.content[1]],
+        number: 1,
+        totalPages: 2,
+        size: 1,
+      },
+    })
+
+    const wrapper = mount(AdminView)
+    await flushPromises()
+
+    await wrapper.findAll('.pagination .btn')[1].trigger('click')
+    await flushPromises()
+
+    expect(mockGet).toHaveBeenLastCalledWith('/admin/users?page=1&size=20')
+    expect(wrapper.text()).toContain('Page 2 of 2')
+  })
 })

--- a/frontend/src/views/__tests__/ChatView.test.ts
+++ b/frontend/src/views/__tests__/ChatView.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import ChatView from '../ChatView.vue'
+import { useProfileStore } from '@/stores/profile'
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push: vi.fn() }),
@@ -59,6 +60,23 @@ describe('ChatView', () => {
     setActivePinia(createPinia())
     mockGet.mockReset().mockResolvedValue({ data: [] })
     mockPost.mockReset().mockResolvedValue({ data: mockChatResponse })
+    const profileStore = useProfileStore()
+    profileStore.profile = {
+      id: 1,
+      userId: 1,
+      displayName: null,
+      avatarUrl: null,
+      timezone: null,
+      notificationPrefs: null,
+      telegramChatId: null,
+      whatsappNumber: null,
+      tutorialCompleted: false,
+      onboardingCompleted: true,
+      surveyCompleted: true,
+      isPatient: true,
+      isTherapist: false,
+      aiConsentGiven: true,
+    }
   })
 
   it('renders page header', () => {
@@ -142,5 +160,142 @@ describe('ChatView', () => {
 
     expect(wrapper.find('.error-message').exists()).toBe(true)
     expect(wrapper.find('.error-message').text()).toContain('Failed to load conversations')
+  })
+
+  it('sends a message from the textarea', async () => {
+    mockGet.mockResolvedValueOnce({ data: [] }).mockResolvedValueOnce({ data: [] })
+    const wrapper = mount(ChatView)
+    await flushPromises()
+
+    await wrapper.find('.message-input').setValue('How am I doing?')
+    await wrapper.find('.send-btn').trigger('click')
+    await flushPromises()
+
+    expect(mockPost).toHaveBeenCalledWith('/ai/chat', {
+      message: 'How am I doing?',
+      conversationId: null,
+      type: 'COACHING',
+    })
+    expect(wrapper.text()).toContain('Here is my response.')
+  })
+
+  it('sends on Enter but not on Shift+Enter', async () => {
+    mockGet.mockResolvedValueOnce({ data: [] }).mockResolvedValueOnce({ data: [] })
+    const wrapper = mount(ChatView)
+    await flushPromises()
+
+    const input = wrapper.find('.message-input')
+    await input.setValue('Check in')
+    await input.trigger('keydown', {
+      key: 'Enter',
+      shiftKey: true,
+      preventDefault: vi.fn(),
+    })
+    expect(mockPost).not.toHaveBeenCalled()
+
+    await input.trigger('keydown', {
+      key: 'Enter',
+      shiftKey: false,
+      preventDefault: vi.fn(),
+    })
+    await flushPromises()
+
+    expect(mockPost).toHaveBeenCalledTimes(1)
+  })
+
+  it('loads another conversation when a sidebar item is clicked', async () => {
+    mockGet
+      .mockResolvedValueOnce({ data: mockConversations })
+      .mockResolvedValueOnce({ data: mockConversationDetail })
+      .mockResolvedValueOnce({ data: mockConversations[1] })
+    const wrapper = mount(ChatView)
+    await flushPromises()
+
+    await wrapper.findAll('.conversation-item')[1].trigger('click')
+    await flushPromises()
+
+    const messages = wrapper.findAll('.message')
+    expect(messages).toHaveLength(1)
+    expect(messages[0].text()).toContain('Earlier chat')
+  })
+
+  it('shows the consent dialog when AI consent is missing', async () => {
+    const profileStore = useProfileStore()
+    profileStore.profile = { ...profileStore.profile!, aiConsentGiven: false }
+    mockGet.mockResolvedValueOnce({ data: [] })
+    const wrapper = mount(ChatView)
+    await flushPromises()
+
+    await wrapper.find('.message-input').setValue('Need support')
+    await wrapper.find('.send-btn').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('dialog').exists()).toBe(true)
+  })
+
+  it('retries the pending message after consent is accepted', async () => {
+    const profileStore = useProfileStore()
+    profileStore.profile = { ...profileStore.profile!, aiConsentGiven: false }
+    mockGet.mockResolvedValueOnce({ data: [] }).mockResolvedValueOnce({ data: [] })
+    const wrapper = mount(ChatView, {
+      global: {
+        stubs: {
+          AiConsentDialog: {
+            template: '<button class="accept-consent" @click="$emit(\'accepted\')">Accept</button>',
+          },
+        },
+      },
+    })
+    await flushPromises()
+
+    await wrapper.find('.message-input').setValue('Need support')
+    await wrapper.find('.send-btn').trigger('click')
+    await flushPromises()
+
+    profileStore.profile = { ...profileStore.profile!, aiConsentGiven: true }
+    await wrapper.find('.accept-consent').trigger('click')
+    await flushPromises()
+
+    expect(mockPost).toHaveBeenCalledWith('/ai/chat', {
+      message: 'Need support',
+      conversationId: null,
+      type: 'COACHING',
+    })
+  })
+
+  it('clears the consent error when consent is declined', async () => {
+    const profileStore = useProfileStore()
+    profileStore.profile = { ...profileStore.profile!, aiConsentGiven: false }
+    mockGet.mockResolvedValueOnce({ data: [] })
+    const wrapper = mount(ChatView, {
+      global: {
+        stubs: {
+          AiConsentDialog: {
+            template:
+              '<button class="decline-consent" @click="$emit(\'declined\')">Decline</button>',
+          },
+        },
+      },
+    })
+    await flushPromises()
+
+    await wrapper.find('.message-input').setValue('Need support')
+    await wrapper.find('.send-btn').trigger('click')
+    await flushPromises()
+
+    await wrapper.find('.decline-consent').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('.decline-consent').exists()).toBe(false)
+  })
+
+  it('dismisses non-consent errors', async () => {
+    mockGet.mockRejectedValueOnce(new Error('Network error'))
+    const wrapper = mount(ChatView)
+    await flushPromises()
+
+    await wrapper.find('.error-message .btn').trigger('click')
+
+    expect(wrapper.find('.error-message').exists()).toBe(false)
   })
 })

--- a/frontend/src/views/__tests__/InterviewFormView.test.ts
+++ b/frontend/src/views/__tests__/InterviewFormView.test.ts
@@ -4,17 +4,25 @@ import { createPinia, setActivePinia } from 'pinia'
 import InterviewFormView from '../InterviewFormView.vue'
 
 const mockPush = vi.fn()
+const routeState = vi.hoisted(() => ({
+  name: 'interview-new',
+  params: {} as Record<string, string>,
+}))
 vi.mock('vue-router', () => ({
-  useRoute: () => ({ name: 'interview-new', params: {} }),
+  useRoute: () => routeState,
   useRouter: () => ({ push: mockPush }),
 }))
 
+const mockGet = vi.fn()
+const mockPost = vi.fn()
+const mockPut = vi.fn()
+const mockDelete = vi.fn()
 vi.mock('@/services/api', () => ({
   default: {
-    get: vi.fn(),
-    post: vi.fn(),
-    put: vi.fn(),
-    delete: vi.fn(),
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+    put: (...args: unknown[]) => mockPut(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
   },
 }))
 
@@ -22,6 +30,12 @@ describe('InterviewFormView', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     mockPush.mockClear()
+    routeState.name = 'interview-new'
+    routeState.params = {}
+    mockGet.mockReset()
+    mockPost.mockReset()
+    mockPut.mockReset()
+    mockDelete.mockReset()
   })
 
   it('renders new interview form', () => {
@@ -84,9 +98,7 @@ describe('InterviewFormView', () => {
   })
 
   it('submits form and navigates to detail', async () => {
-    const { default: api } = await import('@/services/api')
-    const mockApi = api as unknown as { post: ReturnType<typeof vi.fn> }
-    mockApi.post.mockResolvedValue({
+    mockPost.mockResolvedValue({
       data: { id: 5, interviewDate: '2025-01-15' },
     })
 
@@ -95,7 +107,7 @@ describe('InterviewFormView', () => {
     await wrapper.find('form').trigger('submit')
     await flushPromises()
 
-    expect(mockApi.post).toHaveBeenCalledWith('/interviews', expect.any(Object))
+    expect(mockPost).toHaveBeenCalledWith('/interviews', expect.any(Object))
     expect(mockPush).toHaveBeenCalledWith({ name: 'interview-detail', params: { id: 5 } })
   })
 
@@ -103,5 +115,100 @@ describe('InterviewFormView', () => {
     const wrapper = mount(InterviewFormView)
     expect(wrapper.find('.btn-back').exists()).toBe(true)
     expect(wrapper.find('.btn-back').text()).toContain('Back')
+  })
+
+  it('adds a topic on Enter key', async () => {
+    const wrapper = mount(InterviewFormView)
+
+    await wrapper.find('#topic-input').setValue('sleep')
+    await wrapper.find('#topic-input').trigger('keydown', { key: 'Enter' })
+
+    expect(wrapper.findAll('.topic-chip')).toHaveLength(1)
+    expect(wrapper.text()).toContain('sleep')
+  })
+
+  it('loads an existing interview and updates it', async () => {
+    routeState.name = 'interview-edit'
+    routeState.params = { id: '9' }
+    mockGet.mockResolvedValueOnce({
+      data: {
+        id: 9,
+        interviewDate: '2025-01-20',
+        moodBefore: 4,
+        moodAfter: 6,
+        topics: ['anxiety'],
+        medicationChanges: 'Lower dose',
+        recommendations: 'Walk more',
+        notes: 'Follow up',
+        hasAudio: true,
+        transcriptionText: 'Transcript',
+        audioExpiresAt: null,
+      },
+    })
+    mockPut.mockResolvedValueOnce({
+      data: { id: 9, interviewDate: '2025-01-20' },
+    })
+
+    const wrapper = mount(InterviewFormView, {
+      global: {
+        stubs: {
+          AudioSection: { template: '<div class="audio-section-stub" />' },
+        },
+      },
+    })
+    await flushPromises()
+
+    expect(wrapper.find('h1').text()).toBe('Edit Interview')
+    expect((wrapper.find('#medication-changes').element as HTMLTextAreaElement).value).toBe(
+      'Lower dose',
+    )
+    expect(wrapper.find('.audio-section-stub').exists()).toBe(true)
+
+    await wrapper.find('#notes').setValue('Updated notes')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(mockPut).toHaveBeenCalledWith('/interviews/9', expect.any(Object))
+    expect(mockPush).toHaveBeenCalledWith({ name: 'interview-detail', params: { id: 9 } })
+  })
+
+  it('goes back to the detail page while editing', async () => {
+    routeState.name = 'interview-edit'
+    routeState.params = { id: '11' }
+    mockGet.mockResolvedValueOnce({
+      data: {
+        id: 11,
+        interviewDate: '2025-01-20',
+        moodBefore: null,
+        moodAfter: null,
+        topics: [],
+        medicationChanges: null,
+        recommendations: null,
+        notes: null,
+        hasAudio: false,
+        transcriptionText: null,
+        audioExpiresAt: null,
+      },
+    })
+
+    const wrapper = mount(InterviewFormView)
+    await flushPromises()
+
+    await wrapper.find('.btn-back').trigger('click')
+
+    expect(mockPush).toHaveBeenCalledWith({ name: 'interview-detail', params: { id: 11 } })
+  })
+
+  it('shows an error banner when save fails and allows dismissing it', async () => {
+    mockPost.mockRejectedValueOnce(new Error('save failed'))
+
+    const wrapper = mount(InterviewFormView)
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.find('.error-banner').exists()).toBe(true)
+    await wrapper.find('.error-dismiss').trigger('click')
+    expect(wrapper.find('.error-banner').exists()).toBe(false)
+    expect(mockPush).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/views/__tests__/InviteView.test.ts
+++ b/frontend/src/views/__tests__/InviteView.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import InviteView from '../InviteView.vue'
+import { useAuthStore } from '@/stores/auth'
+
+const mockPush = vi.fn()
+const mockRoute = {
+  params: { token: 'invite-token' },
+  fullPath: '/invite/invite-token',
+}
+
+vi.mock('vue-router', () => ({
+  useRoute: () => mockRoute,
+  useRouter: () => ({ push: mockPush }),
+}))
+
+const fetchMock = vi.fn()
+
+describe('InviteView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockPush.mockReset()
+    fetchMock.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  it('shows loading state before preview resolves', async () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+
+    const wrapper = mount(InviteView)
+
+    expect(wrapper.text()).toContain('Loading invite...')
+  })
+
+  it('renders invite preview details after loading', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ initiatorName: 'Dr Smith', initiatorRole: 'THERAPIST' }),
+    })
+
+    const wrapper = mount(InviteView)
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/invites/invite-token')
+    expect(wrapper.text()).toContain("You've been invited")
+    expect(wrapper.text()).toContain('Dr Smith')
+    expect(wrapper.text()).toContain('(Therapist)')
+  })
+
+  it('shows preview fetch error when invite is invalid', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false })
+
+    const wrapper = mount(InviteView)
+    await flushPromises()
+
+    expect(wrapper.find('.error-msg').text()).toContain('Invalid or expired invite link')
+  })
+
+  it('redirects unauthenticated users to login when accepting', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ initiatorName: 'Alex', initiatorRole: 'PATIENT' }),
+    })
+
+    const wrapper = mount(InviteView)
+    await flushPromises()
+
+    await wrapper.find('.accept-btn').trigger('click')
+
+    expect(mockPush).toHaveBeenCalledWith({
+      name: 'login',
+      query: { redirect: '/invite/invite-token' },
+    })
+  })
+
+  it('accepts invite and redirects authenticated users to dashboard', async () => {
+    const authStore = useAuthStore()
+    authStore.setUser({
+      id: '1',
+      email: 'test@example.com',
+      name: 'Test User',
+      role: 'PATIENT',
+      isPatient: true,
+      isTherapist: false,
+    })
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ initiatorName: 'Dr Smith', initiatorRole: 'THERAPIST' }),
+      })
+      .mockResolvedValueOnce({ ok: true })
+
+    const wrapper = mount(InviteView)
+    await flushPromises()
+
+    await wrapper.find('.accept-btn').trigger('click')
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenLastCalledWith('/api/invites/invite-token/accept', {
+      method: 'POST',
+    })
+    expect(mockPush).toHaveBeenCalledWith({ name: 'dashboard' })
+  })
+
+  it('shows an error when invite acceptance fails', async () => {
+    const authStore = useAuthStore()
+    authStore.setUser({
+      id: '1',
+      email: 'test@example.com',
+      name: 'Test User',
+      role: 'PATIENT',
+      isPatient: true,
+      isTherapist: false,
+    })
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ initiatorName: 'Dr Smith', initiatorRole: 'THERAPIST' }),
+      })
+      .mockResolvedValueOnce({ ok: false })
+
+    const wrapper = mount(InviteView)
+    await flushPromises()
+
+    await wrapper.find('.accept-btn').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('.error-msg').text()).toContain('Failed to accept invite')
+    expect(mockPush).not.toHaveBeenCalledWith({ name: 'dashboard' })
+  })
+})

--- a/frontend/src/views/__tests__/JournalFormView.test.ts
+++ b/frontend/src/views/__tests__/JournalFormView.test.ts
@@ -4,18 +4,23 @@ import { createPinia, setActivePinia } from 'pinia'
 import JournalFormView from '../JournalFormView.vue'
 
 const mockPush = vi.fn()
+const routeState = vi.hoisted(() => ({ name: 'journal-new', params: {} as Record<string, string> }))
 vi.mock('vue-router', () => ({
-  useRoute: () => ({ name: 'journal-new', params: {} }),
+  useRoute: () => routeState,
   useRouter: () => ({ push: mockPush }),
 }))
 
+const mockGet = vi.fn().mockResolvedValue({ data: [] })
+const mockPost = vi.fn()
+const mockPut = vi.fn()
+const mockDelete = vi.fn()
 vi.mock('@/services/api', () => ({
   default: {
-    get: vi.fn().mockResolvedValue({ data: [] }),
-    post: vi.fn(),
-    put: vi.fn(),
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+    put: (...args: unknown[]) => mockPut(...args),
     patch: vi.fn(),
-    delete: vi.fn(),
+    delete: (...args: unknown[]) => mockDelete(...args),
   },
 }))
 
@@ -23,6 +28,12 @@ describe('JournalFormView', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     mockPush.mockClear()
+    routeState.name = 'journal-new'
+    routeState.params = {}
+    mockGet.mockReset().mockResolvedValue({ data: [] })
+    mockPost.mockReset()
+    mockPut.mockReset()
+    mockDelete.mockReset()
   })
 
   it('renders new entry form', () => {
@@ -60,9 +71,7 @@ describe('JournalFormView', () => {
   })
 
   it('submits form and navigates to journal list', async () => {
-    const { default: api } = await import('@/services/api')
-    const mockApi = api as unknown as { post: ReturnType<typeof vi.fn> }
-    mockApi.post.mockResolvedValue({
+    mockPost.mockResolvedValue({
       data: { id: 1, entryDate: '2025-01-15', title: 'Test', tags: [] },
     })
 
@@ -71,7 +80,7 @@ describe('JournalFormView', () => {
     await wrapper.find('form').trigger('submit')
     await flushPromises()
 
-    expect(mockApi.post).toHaveBeenCalledWith('/journal', expect.any(Object))
+    expect(mockPost).toHaveBeenCalledWith('/journal', expect.any(Object))
     expect(mockPush).toHaveBeenCalledWith({ name: 'journal' })
   })
 
@@ -79,5 +88,64 @@ describe('JournalFormView', () => {
     const wrapper = mount(JournalFormView)
     expect(wrapper.find('.checkbox').exists()).toBe(true)
     expect(wrapper.text()).toContain('Share with therapist')
+  })
+
+  it('adds and removes tags from the form', async () => {
+    const wrapper = mount(JournalFormView)
+
+    await wrapper.find('#tag-input').setValue('gratitude')
+    await wrapper.find('#tag-input').trigger('keydown.enter')
+    expect(wrapper.text()).toContain('gratitude')
+
+    await wrapper.find('.tag-remove').trigger('click')
+    expect(wrapper.text()).not.toContain('gratitude')
+  })
+
+  it('loads an existing entry for editing and updates it', async () => {
+    routeState.name = 'journal-edit'
+    routeState.params = { id: '7' }
+    mockGet.mockResolvedValueOnce({
+      data: [
+        {
+          id: 7,
+          entryDate: '2025-01-12',
+          title: 'Existing title',
+          content: 'Existing content',
+          mood: 8,
+          tags: ['sleep'],
+          sharedWithTherapist: true,
+        },
+      ],
+    })
+    mockPut.mockResolvedValueOnce({
+      data: { id: 7, entryDate: '2025-01-12', title: 'Updated', tags: ['sleep'] },
+    })
+
+    const wrapper = mount(JournalFormView)
+    await flushPromises()
+
+    expect((wrapper.find('#entry-title').element as HTMLInputElement).value).toBe('Existing title')
+    expect(wrapper.find('h1').text()).toBe('Edit Entry')
+
+    await wrapper.find('#entry-title').setValue('Updated')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(mockPut).toHaveBeenCalledWith('/journal/7', expect.any(Object))
+    expect(mockPush).toHaveBeenCalledWith({ name: 'journal' })
+  })
+
+  it('shows and dismisses submission errors', async () => {
+    mockPost.mockRejectedValueOnce(new Error('boom'))
+
+    const wrapper = mount(JournalFormView)
+    await wrapper.find('#entry-title').setValue('Test entry')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.find('.error-banner').exists()).toBe(true)
+    await wrapper.find('.error-dismiss').trigger('click')
+    expect(wrapper.find('.error-banner').exists()).toBe(false)
+    expect(mockPush).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/views/__tests__/LandingView.test.ts
+++ b/frontend/src/views/__tests__/LandingView.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import LandingView from '../LandingView.vue'
+
+const pushMock = vi.fn()
+const authState = vi.hoisted(() => ({
+  isAuthenticated: false,
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: pushMock }),
+}))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => authState,
+}))
+
+vi.mock('@/components/landing/HeroSection.vue', () => ({
+  default: {
+    props: ['onSignIn'],
+    template: '<button class="hero-signin" @click="onSignIn()">Sign in</button>',
+  },
+}))
+
+vi.mock('@/components/landing/FeaturesSection.vue', () => ({
+  default: { template: '<section class="features-stub" />' },
+}))
+
+vi.mock('@/components/landing/BenefitsSection.vue', () => ({
+  default: { template: '<section class="benefits-stub" />' },
+}))
+
+vi.mock('@/components/landing/FooterSection.vue', () => ({
+  default: { template: '<footer class="footer-stub" />' },
+}))
+
+describe('LandingView', () => {
+  beforeEach(() => {
+    pushMock.mockReset()
+    authState.isAuthenticated = false
+    Object.defineProperty(globalThis, 'location', {
+      value: { href: 'http://localhost/' },
+      configurable: true,
+    })
+  })
+
+  it('renders the landing sections', () => {
+    const wrapper = mount(LandingView)
+
+    expect(wrapper.find('.hero-signin').exists()).toBe(true)
+    expect(wrapper.find('.features-stub').exists()).toBe(true)
+    expect(wrapper.find('.benefits-stub').exists()).toBe(true)
+    expect(wrapper.find('.footer-stub').exists()).toBe(true)
+  })
+
+  it('routes authenticated users to the dashboard on sign in', async () => {
+    authState.isAuthenticated = true
+    const wrapper = mount(LandingView)
+
+    await wrapper.find('.hero-signin').trigger('click')
+
+    expect(pushMock).toHaveBeenCalledWith('/dashboard')
+  })
+
+  it('redirects unauthenticated users to Google OAuth', async () => {
+    const wrapper = mount(LandingView)
+
+    await wrapper.find('.hero-signin').trigger('click')
+
+    expect(globalThis.location.href).toBe('/api/oauth2/authorization/google')
+  })
+})

--- a/frontend/src/views/__tests__/LoginView.test.ts
+++ b/frontend/src/views/__tests__/LoginView.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import LoginView from '../LoginView.vue'
+
+const replaceMock = vi.fn()
+const authState = vi.hoisted(() => ({
+  isAuthenticated: false,
+  fetchCurrentUser: vi.fn(),
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ replace: replaceMock }),
+}))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => authState,
+}))
+
+describe('LoginView', () => {
+  beforeEach(() => {
+    replaceMock.mockReset()
+    authState.isAuthenticated = false
+    authState.fetchCurrentUser.mockReset().mockResolvedValue(undefined)
+  })
+
+  it('shows the signing-in message', () => {
+    const wrapper = mount(LoginView)
+    expect(wrapper.text()).toContain('Signing you in...')
+  })
+
+  it('redirects authenticated users to the dashboard after fetching', async () => {
+    authState.fetchCurrentUser.mockImplementation(async () => {
+      authState.isAuthenticated = true
+    })
+
+    mount(LoginView)
+    await flushPromises()
+
+    expect(authState.fetchCurrentUser).toHaveBeenCalled()
+    expect(replaceMock).toHaveBeenCalledWith('/dashboard')
+  })
+
+  it('redirects unauthenticated users back to landing', async () => {
+    mount(LoginView)
+    await flushPromises()
+
+    expect(replaceMock).toHaveBeenCalledWith('/')
+  })
+})

--- a/frontend/src/views/__tests__/OnboardingView.test.ts
+++ b/frontend/src/views/__tests__/OnboardingView.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import OnboardingView from '../OnboardingView.vue'
+import { useProfileStore } from '@/stores/profile'
+
+const mockPush = vi.fn()
+
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-router')>()
+  return {
+    ...actual,
+    useRouter: () => ({ push: mockPush }),
+  }
+})
+
+describe('OnboardingView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockPush.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('requires at least one role before continuing', async () => {
+    const wrapper = mount(OnboardingView)
+    const checkboxes = wrapper.findAll('.role-checkbox')
+
+    await checkboxes[0].setValue(false)
+    await checkboxes[1].setValue(false)
+    await wrapper.find('.submit-btn').trigger('click')
+
+    expect(wrapper.find('.error-msg').text()).toContain('Please select at least one role')
+  })
+
+  it('moves to survey mode after roles are saved', async () => {
+    const profileStore = useProfileStore()
+    const updateRolesSpy = vi.spyOn(profileStore, 'updateRoles').mockResolvedValue(undefined)
+
+    const wrapper = mount(OnboardingView)
+    await wrapper.find('.submit-btn').trigger('click')
+    await flushPromises()
+
+    expect(updateRolesSpy).toHaveBeenCalledWith(true, false)
+    expect(wrapper.text()).toContain('Tell us about yourself')
+  })
+
+  it('shows a role setup error when role save fails', async () => {
+    const profileStore = useProfileStore()
+    vi.spyOn(profileStore, 'updateRoles').mockRejectedValue(new Error('boom'))
+
+    const wrapper = mount(OnboardingView)
+    await wrapper.find('.submit-btn').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('.error-msg').text()).toContain('Could not set roles')
+  })
+
+  it('submits the survey and redirects to the dashboard', async () => {
+    vi.useFakeTimers()
+    const profileStore = useProfileStore()
+    vi.spyOn(profileStore, 'updateRoles').mockResolvedValue(undefined)
+    const submitSurveySpy = vi.spyOn(profileStore, 'submitSurvey').mockResolvedValue(undefined)
+
+    const wrapper = mount(OnboardingView)
+    await wrapper.find('.submit-btn').trigger('click')
+    await flushPromises()
+
+    const chips = wrapper.findAll('.chip')
+    await chips[0].trigger('click')
+    await wrapper.find('.survey-actions .submit-btn').trigger('click')
+    await flushPromises()
+
+    expect(submitSurveySpy).toHaveBeenCalledWith(
+      expect.objectContaining({ lifeAreas: ['Work'], moodBaseline: 5, anxietyLevel: 5 }),
+    )
+    expect(wrapper.text()).toContain('Your goals are ready!')
+
+    await vi.advanceTimersByTimeAsync(1500)
+    expect(mockPush).toHaveBeenCalledWith({ name: 'dashboard' })
+  })
+
+  it('skips the survey and redirects to the dashboard', async () => {
+    const profileStore = useProfileStore()
+    vi.spyOn(profileStore, 'updateRoles').mockResolvedValue(undefined)
+    const skipSurveySpy = vi.spyOn(profileStore, 'skipSurvey').mockResolvedValue(undefined)
+
+    const wrapper = mount(OnboardingView)
+    await wrapper.find('.submit-btn').trigger('click')
+    await flushPromises()
+
+    await wrapper.find('.skip-btn').trigger('click')
+    await flushPromises()
+
+    expect(skipSurveySpy).toHaveBeenCalled()
+    expect(mockPush).toHaveBeenCalledWith({ name: 'dashboard' })
+  })
+
+  it('shows a survey submission error when submit fails', async () => {
+    const profileStore = useProfileStore()
+    vi.spyOn(profileStore, 'updateRoles').mockResolvedValue(undefined)
+    vi.spyOn(profileStore, 'submitSurvey').mockRejectedValue(new Error('boom'))
+
+    const wrapper = mount(OnboardingView)
+    await wrapper.find('.submit-btn').trigger('click')
+    await flushPromises()
+
+    await wrapper.find('.survey-actions .submit-btn').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('.error-msg').text()).toContain('Something went wrong')
+  })
+})

--- a/frontend/src/views/__tests__/ProfileView.test.ts
+++ b/frontend/src/views/__tests__/ProfileView.test.ts
@@ -2,9 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import ProfileView from '../ProfileView.vue'
+import { useAuthStore } from '@/stores/auth'
+import { useProfileStore } from '@/stores/profile'
 
+const mockPush = vi.fn()
 vi.mock('vue-router', () => ({
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push: mockPush }),
 }))
 
 // Ensure localStorage is available in test environment
@@ -36,22 +39,27 @@ const mockProfile = {
 
 const mockGet = vi.fn().mockResolvedValue({ data: mockProfile })
 const mockPut = vi.fn().mockResolvedValue({ data: mockProfile })
+const mockPatch = vi.fn().mockResolvedValue({})
+const mockDelete = vi.fn().mockResolvedValue({})
 vi.mock('@/services/api', () => ({
   default: {
     get: (...args: unknown[]) => mockGet(...args),
     post: vi.fn(),
     put: (...args: unknown[]) => mockPut(...args),
-    patch: vi.fn(),
-    delete: vi.fn(),
+    patch: (...args: unknown[]) => mockPatch(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
   },
 }))
 
 describe('ProfileView', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
+    mockPush.mockReset()
     localStorageMock.getItem.mockReturnValue(null)
     mockGet.mockReset().mockResolvedValue({ data: mockProfile })
     mockPut.mockReset().mockResolvedValue({ data: mockProfile })
+    mockPatch.mockReset().mockResolvedValue({})
+    mockDelete.mockReset().mockResolvedValue({})
   })
 
   it('renders page header', () => {
@@ -141,5 +149,131 @@ describe('ProfileView', () => {
 
     expect(wrapper.find('.error-message').exists()).toBe(true)
     expect(wrapper.find('.error-message').text()).toContain('Failed to load profile')
+  })
+
+  it('unlinks telegram and WhatsApp identifiers', async () => {
+    const wrapper = mount(ProfileView)
+    await flushPromises()
+
+    const unlinkButtons = wrapper.findAll('.input-with-action .btn-danger')
+    await unlinkButtons[0].trigger('click')
+    await unlinkButtons[1].trigger('click')
+
+    expect((wrapper.find('#telegramChatId').element as HTMLInputElement).value).toBe('')
+    expect((wrapper.find('#whatsappNumber').element as HTMLInputElement).value).toBe('')
+  })
+
+  it('shows a validation error when all roles are deselected', async () => {
+    const wrapper = mount(ProfileView)
+    await flushPromises()
+
+    const roleCheckboxes = wrapper.findAll('.role-toggle-group input[type="checkbox"]')
+    await roleCheckboxes[0].setValue(false)
+    await roleCheckboxes[1].setValue(false)
+    await wrapper.findAll('.form-section')[1].find('.btn.btn-secondary').trigger('click')
+
+    expect(wrapper.text()).toContain('At least one role must be selected.')
+  })
+
+  it('saves roles successfully', async () => {
+    const store = useProfileStore()
+    const updateRolesSpy = vi.spyOn(store, 'updateRoles').mockResolvedValue(undefined)
+    const wrapper = mount(ProfileView)
+    await flushPromises()
+
+    const roleCheckboxes = wrapper.findAll('.role-toggle-group input[type="checkbox"]')
+    await roleCheckboxes[1].setValue(true)
+    await wrapper.findAll('.form-section')[1].find('.btn.btn-secondary').trigger('click')
+    await flushPromises()
+
+    expect(updateRolesSpy).toHaveBeenCalledWith(true, true)
+    expect(wrapper.text()).toContain('Roles updated successfully.')
+  })
+
+  it('shows a role error when saving roles fails', async () => {
+    const store = useProfileStore()
+    vi.spyOn(store, 'updateRoles').mockRejectedValue(new Error('boom'))
+    const wrapper = mount(ProfileView)
+    await flushPromises()
+
+    await wrapper.findAll('.form-section')[1].find('.btn.btn-secondary').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Could not update roles')
+  })
+
+  it('submits the inline survey baseline', async () => {
+    const store = useProfileStore()
+    const submitSurveySpy = vi.spyOn(store, 'submitSurvey').mockResolvedValue(undefined)
+    const wrapper = mount(ProfileView)
+    await flushPromises()
+
+    const toggleSurveyButton = wrapper
+      .findAll('button')
+      .find((button) => button.text().includes('Complete Survey'))
+    await toggleSurveyButton!.trigger('click')
+    await wrapper.find('.chip').trigger('click')
+    await wrapper.find('#wellness-baseline .btn.btn-primary').trigger('click')
+    await flushPromises()
+
+    expect(submitSurveySpy).toHaveBeenCalledWith(
+      expect.objectContaining({ lifeAreas: ['Work'], moodBaseline: 5, anxietyLevel: 5 }),
+    )
+  })
+
+  it('replays the tutorial and redirects to dashboard', async () => {
+    const store = useProfileStore()
+    const updateProfileSpy = vi.spyOn(store, 'updateProfile').mockResolvedValue({
+      ...mockProfile,
+      tutorialCompleted: false,
+    })
+    const wrapper = mount(ProfileView)
+    await flushPromises()
+
+    const replayButton = wrapper
+      .findAll('button')
+      .find((button) => button.text() === 'Replay Tutorial')
+    await replayButton!.trigger('click')
+    await flushPromises()
+
+    expect(updateProfileSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ tutorialCompleted: false }),
+    )
+    expect(mockPush).toHaveBeenCalledWith('/dashboard')
+  })
+
+  it('deletes the account after confirmation', async () => {
+    const authStore = useAuthStore()
+    const deleteAccountSpy = vi.spyOn(authStore, 'deleteAccount').mockResolvedValue(undefined)
+    const wrapper = mount(ProfileView)
+    await flushPromises()
+
+    const openDeleteButton = wrapper
+      .findAll('button')
+      .find((button) => button.text() === 'Delete Account')
+    await openDeleteButton!.trigger('click')
+    await wrapper.find('.delete-confirm-input').setValue('DELETE')
+    await wrapper.find('.delete-confirm-actions .btn-danger').trigger('click')
+    await flushPromises()
+
+    expect(deleteAccountSpy).toHaveBeenCalled()
+    expect(mockPush).toHaveBeenCalledWith('/login')
+  })
+
+  it('shows an error when account deletion fails', async () => {
+    const authStore = useAuthStore()
+    vi.spyOn(authStore, 'deleteAccount').mockRejectedValue(new Error('boom'))
+    const wrapper = mount(ProfileView)
+    await flushPromises()
+
+    const openDeleteButton = wrapper
+      .findAll('button')
+      .find((button) => button.text() === 'Delete Account')
+    await openDeleteButton!.trigger('click')
+    await wrapper.find('.delete-confirm-input').setValue('DELETE')
+    await wrapper.find('.delete-confirm-actions .btn-danger').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Could not delete account')
   })
 })


### PR DESCRIPTION
Closes #224

## Summary
- add backend tests around auth, profile, messaging, and interview storage/transcription paths
- add frontend tests around app bootstrap, api clients, stores, views, and key UI components
- raise local coverage to backend 82.98%, frontend 89.38%, combined 85.01%

## Validation
- cd backend && mvn verify -B
- cd frontend && npm run test:coverage