### PR TITLE
chore(deps): fix renovate branches recreated daily without PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
   "groupName": "all dependencies",
   "automerge": true,
   "platformAutomerge": true,
+  "prCreation": "immediate",
   "packageRules": [
     {
       "matchManagers": ["maven"],


### PR DESCRIPTION
## Summary
- Adds `\"prCreation\": \"immediate\"` to `renovate.json`
- Root cause: `config:recommended` defaults to `prCreation: \"not-pending\"`, which makes Renovate create a branch and wait for CI to pass before opening a PR — but the `cleanup-orphan-branches` job deletes any `renovate/*` branch without an open PR in the same workflow run, so the PR is never created and the cycle repeats daily
- With `immediate`, Renovate opens the PR right away; the cleanup job leaves it alone; the existing CI → auto-approve → auto-merge chain handles the rest

## Test plan
- [ ] After merge, trigger Renovate manually — verify a `renovate/all-dependencies` PR is opened (not just a branch)
- [ ] Verify the cleanup job leaves the branch alone (open PR exists)

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)