### PR TITLE
fix(docker): add missing messaging config to application-docker.yml

### DIFF
--- a/backend/src/main/resources/application-docker.yml
+++ b/backend/src/main/resources/application-docker.yml
@@ -52,6 +52,12 @@ mindtrack:
   ai:
     whisper-api-url: https://api.openai.com/v1/audio/transcriptions
     whisper-api-key: ${OPENAI_API_KEY:dummy-key-for-local}
+  messaging:
+    telegram:
+      bot-token: ${TELEGRAM_BOT_TOKEN:}
+      webhook-secret: ${TELEGRAM_WEBHOOK_SECRET:local-dev-docker-webhook-secret}
+    whatsapp:
+      enabled: false
 
 logging:
   level:

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,3 +1,4 @@
 GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-client-secret
 JWT_SECRET=change-me-use-openssl-rand-hex-32-for-local-dev
+TELEGRAM_WEBHOOK_SECRET=change-me-use-openssl-rand-hex-32-for-local-dev


### PR DESCRIPTION
## Root cause

The `docker` profile loads only `application.yml` + `application-docker.yml`. Neither had a `messaging` section, so `telegram.webhook-secret` defaulted to `""` and `TelegramWebhookController.validateConfig()` threw on startup:

> mindtrack.messaging.telegram.webhook-secret must not be blank

The `local` profile wasn't affected because `application-local.yml` already had the messaging config.

## Changes

- Added `mindtrack.messaging.telegram` and `mindtrack.messaging.whatsapp` sections to `application-docker.yml`
- `webhook-secret` reads from `TELEGRAM_WEBHOOK_SECRET` env var, with a local-dev default so Docker Compose works out of the box
- `whatsapp.enabled: false` matches the local profile (WhatsApp not yet configured)
- Added `TELEGRAM_WEBHOOK_SECRET` to `docker/.env.example`

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)