### PR TITLE
feat(goals): add category-based icons to goal cards

### DIFF
--- a/frontend/src/composables/__tests__/useGoalIcon.test.ts
+++ b/frontend/src/composables/__tests__/useGoalIcon.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { useGoalIcon } from '../useGoalIcon'
+
+describe('useGoalIcon', () => {
+  const { getGoalIcon } = useGoalIcon()
+
+  it('returns brain emoji for Mental Health', () => {
+    const icon = getGoalIcon('Mental Health')
+    expect(icon.emoji).toBe('🧠')
+    expect(icon.label).toBe('Mental Health')
+  })
+
+  it('returns default icon for unknown category', () => {
+    const icon = getGoalIcon('Unknown Category')
+    expect(icon.emoji).toBe('🎯')
+    expect(icon.label).toBe('Goal')
+  })
+
+  it('returns default icon for null', () => {
+    const icon = getGoalIcon(null)
+    expect(icon.emoji).toBe('🎯')
+  })
+
+  it('returns default icon for undefined', () => {
+    const icon = getGoalIcon(undefined)
+    expect(icon.emoji).toBe('🎯')
+  })
+
+  it('returns correct icons for all mapped categories', () => {
+    expect(getGoalIcon('Wellness').emoji).toBe('✨')
+    expect(getGoalIcon('Health').emoji).toBe('❤️')
+    expect(getGoalIcon('Sleep').emoji).toBe('🌙')
+    expect(getGoalIcon('Stress').emoji).toBe('💨')
+    expect(getGoalIcon('Fitness').emoji).toBe('🏃')
+    expect(getGoalIcon('Work').emoji).toBe('💼')
+    expect(getGoalIcon('Relationships').emoji).toBe('👥')
+  })
+})

--- a/frontend/src/composables/useGoalIcon.ts
+++ b/frontend/src/composables/useGoalIcon.ts
@@ -1,0 +1,26 @@
+export interface GoalIcon {
+  emoji: string
+  label: string
+}
+
+const CATEGORY_ICON_MAP: Record<string, GoalIcon> = {
+  'Mental Health': { emoji: '🧠', label: 'Mental Health' },
+  Wellness: { emoji: '✨', label: 'Wellness' },
+  Health: { emoji: '❤️', label: 'Health' },
+  Sleep: { emoji: '🌙', label: 'Sleep' },
+  Stress: { emoji: '💨', label: 'Stress' },
+  Fitness: { emoji: '🏃', label: 'Fitness' },
+  Work: { emoji: '💼', label: 'Work' },
+  Relationships: { emoji: '👥', label: 'Relationships' },
+}
+
+const DEFAULT_ICON: GoalIcon = { emoji: '🎯', label: 'Goal' }
+
+export function useGoalIcon() {
+  function getGoalIcon(category: string | null | undefined): GoalIcon {
+    if (!category) return DEFAULT_ICON
+    return CATEGORY_ICON_MAP[category] ?? DEFAULT_ICON
+  }
+
+  return { getGoalIcon }
+}

--- a/frontend/src/views/GoalDetailView.vue
+++ b/frontend/src/views/GoalDetailView.vue
@@ -2,10 +2,12 @@
 import { onMounted, reactive, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useGoalsStore, type GoalStatus, type MilestoneForm } from '@/stores/goals'
+import { useGoalIcon } from '@/composables/useGoalIcon'
 
 const route = useRoute()
 const router = useRouter()
 const store = useGoalsStore()
+const { getGoalIcon } = useGoalIcon()
 
 const goalId = Number(route.params.id)
 const showDeleteModal = ref(false)
@@ -120,6 +122,7 @@ const availableStatuses: GoalStatus[] = [
             <h1 class="goal-title">{{ store.currentGoal.title }}</h1>
             <div class="goal-meta">
               <span v-if="store.currentGoal.category" class="goal-category">
+                <span>{{ getGoalIcon(store.currentGoal.category).emoji }}</span>
                 {{ store.currentGoal.category }}
               </span>
               <span v-if="store.currentGoal.targetDate" class="goal-date">

--- a/frontend/src/views/GoalsView.vue
+++ b/frontend/src/views/GoalsView.vue
@@ -2,9 +2,11 @@
 import { onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useGoalsStore, type GoalStatus, type GoalValidationStatus } from '@/stores/goals'
+import { useGoalIcon } from '@/composables/useGoalIcon'
 
 const router = useRouter()
 const store = useGoalsStore()
+const { getGoalIcon } = useGoalIcon()
 
 onMounted(() => {
   store.fetchGoals()
@@ -98,7 +100,12 @@ function validationLabel(status: GoalValidationStatus): string {
             @click="navigateToDetail(goal.id)"
           >
             <div class="goal-header">
-              <h3 class="goal-title">{{ goal.title }}</h3>
+              <h3 class="goal-title">
+                <span class="goal-icon" :aria-label="getGoalIcon(goal.category).label">{{
+                  getGoalIcon(goal.category).emoji
+                }}</span
+                >{{ goal.title }}
+              </h3>
               <div class="goal-badges">
                 <span :class="['status-badge', statusClass(goal.status)]">
                   {{ statusLabel(goal.status) }}
@@ -146,7 +153,12 @@ function validationLabel(status: GoalValidationStatus): string {
             @click="navigateToDetail(goal.id)"
           >
             <div class="goal-header">
-              <h3 class="goal-title">{{ goal.title }}</h3>
+              <h3 class="goal-title">
+                <span class="goal-icon" :aria-label="getGoalIcon(goal.category).label">{{
+                  getGoalIcon(goal.category).emoji
+                }}</span
+                >{{ goal.title }}
+              </h3>
               <span :class="['status-badge', statusClass(goal.status)]">
                 {{ statusLabel(goal.status) }}
               </span>
@@ -290,6 +302,10 @@ function validationLabel(status: GoalValidationStatus): string {
   font-size: var(--font-size-lg);
   font-weight: var(--font-weight-semibold);
   color: var(--color-gray-900);
+}
+
+.goal-icon {
+  margin-right: var(--space-2);
 }
 
 .status-badge {

--- a/frontend/src/views/__tests__/GoalDetailView.test.ts
+++ b/frontend/src/views/__tests__/GoalDetailView.test.ts
@@ -87,7 +87,7 @@ describe('GoalDetailView', () => {
 
     expect(wrapper.find('.goal-title').text()).toBe('Learn meditation')
     expect(wrapper.text()).toContain('Practice daily for 10 minutes')
-    expect(wrapper.find('.goal-category').text()).toBe('Health')
+    expect(wrapper.find('.goal-category').text()).toContain('Health')
   })
 
   it('renders status badge with correct class', async () => {


### PR DESCRIPTION
Adds a frontend-only emoji icon to each goal card derived from the goal's category string. No schema changes required.

- `useGoalIcon` composable maps category strings to emoji + accessible label
- Icons appear on goal cards in GoalsView (active + completed sections)
- Icons appear next to category in GoalDetailView meta section
- Default fallback (🎯) for unknown or null categories
- Full unit test coverage for the composable

Closes #246