### PR TITLE
fix(dashboard): use native progress element in active goals widget

### DIFF
--- a/frontend/src/components/dashboard/ActiveGoalsWidget.vue
+++ b/frontend/src/components/dashboard/ActiveGoalsWidget.vue
@@ -46,15 +46,14 @@ function formatDate(date: string | null): string {
         <h3 class="goal-title">{{ goal.title }}</h3>
 
         <div class="progress-section">
-          <div
+          <progress
             class="progress-bar"
-            role="progressbar"
-            :aria-valuenow="getProgress(goal)"
-            aria-valuemin="0"
-            aria-valuemax="100"
+            :value="getProgress(goal)"
+            max="100"
+            :aria-label="`Progress for ${goal.title}`"
           >
-            <div class="progress-bar__fill" :style="{ width: getProgress(goal) + '%' }"></div>
-          </div>
+            {{ getProgress(goal) }}%
+          </progress>
           <span class="progress-label">
             {{ goal.completedMilestones }}/{{ goal.totalMilestones }} milestones ({{
               getProgress(goal)
@@ -141,17 +140,29 @@ function formatDate(date: string | null): string {
 }
 
 .progress-bar {
+  appearance: none;
+  -webkit-appearance: none;
   height: 6px;
+  width: 100%;
+  border: none;
   background: var(--color-gray-200);
   border-radius: 999px;
   overflow: hidden;
 }
 
-.progress-bar__fill {
-  height: 100%;
+.progress-bar::-webkit-progress-bar {
+  background: var(--color-gray-200);
+  border-radius: 999px;
+}
+
+.progress-bar::-webkit-progress-value {
   background: var(--color-primary);
   border-radius: 999px;
-  transition: width 0.3s ease;
+}
+
+.progress-bar::-moz-progress-bar {
+  background: var(--color-primary);
+  border-radius: 999px;
 }
 
 .progress-label {

--- a/frontend/src/components/dashboard/__tests__/ActiveGoalsWidget.test.ts
+++ b/frontend/src/components/dashboard/__tests__/ActiveGoalsWidget.test.ts
@@ -63,8 +63,9 @@ describe('ActiveGoalsWidget', () => {
       global: { plugins: [router] },
     })
     expect(wrapper.text()).toContain('0%')
-    const fill = wrapper.find('.progress-bar__fill')
-    expect(fill.attributes('style')).toContain('width: 0%')
+    const progress = wrapper.find('progress')
+    expect(progress.attributes('value')).toBe('0')
+    expect(progress.attributes('max')).toBe('100')
   })
 
   it('shows 100% progress when all milestones are complete', () => {
@@ -74,8 +75,8 @@ describe('ActiveGoalsWidget', () => {
       global: { plugins: [router] },
     })
     expect(wrapper.text()).toContain('100%')
-    const fill = wrapper.find('.progress-bar__fill')
-    expect(fill.attributes('style')).toContain('width: 100%')
+    const progress = wrapper.find('progress')
+    expect(progress.attributes('value')).toBe('100')
   })
 
   it('renders goal cards as router-links to goal-detail', () => {


### PR DESCRIPTION
## Summary
- replace the custom `role="progressbar"` implementation with a native `<progress>` element
- preserve the existing visual progress bar styling for the active goals widget
- update widget tests to assert native progress attributes

## Testing
- `cd frontend && npm run test:unit -- ActiveGoalsWidget`
- pre-push hook: backend tests, frontend lint, full frontend unit tests, Terraform validation/tfsec

Closes #255
