### PR TITLE
refactor(frontend): move goal icon helper to outer scope

### DIFF
--- a/frontend/src/composables/useGoalIcon.ts
+++ b/frontend/src/composables/useGoalIcon.ts
@@ -16,11 +16,11 @@ const CATEGORY_ICON_MAP: Record<string, GoalIcon> = {
 
 const DEFAULT_ICON: GoalIcon = { emoji: '🎯', label: 'Goal' }
 
-export function useGoalIcon() {
-  function getGoalIcon(category: string | null | undefined): GoalIcon {
-    if (!category) return DEFAULT_ICON
-    return CATEGORY_ICON_MAP[category] ?? DEFAULT_ICON
-  }
+function getGoalIcon(category: string | null | undefined): GoalIcon {
+  if (!category) return DEFAULT_ICON
+  return CATEGORY_ICON_MAP[category] ?? DEFAULT_ICON
+}
 
+export function useGoalIcon() {
   return { getGoalIcon }
 }


### PR DESCRIPTION
## Summary
- move getGoalIcon to module scope in the goal icon composable
- preserve the existing useGoalIcon API for current consumers
- address the SonarQube maintainability finding without changing behavior

## Testing
- npx eslint frontend/src/composables/useGoalIcon.ts
- cd frontend && npm run test:unit -- src/composables/__tests__/useGoalIcon.test.ts
- pre-push hook (backend tests, frontend lint, frontend unit tests, Terraform validation/tflint/tfsec)

Closes #262
