### PR TITLE
feat(mood): add mood logging endpoint and dashboard widget

### DIFF
--- a/backend/src/main/java/com/mindtrack/mood/controller/MoodEntryController.java
+++ b/backend/src/main/java/com/mindtrack/mood/controller/MoodEntryController.java
@@ -1,0 +1,53 @@
+package com.mindtrack.mood.controller;
+
+import com.mindtrack.mood.dto.MoodEntryRequest;
+import com.mindtrack.mood.dto.MoodEntryResponse;
+import com.mindtrack.mood.service.MoodEntryService;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST controller for mood entry operations.
+ */
+@RestController
+@RequestMapping("/api/mood")
+public class MoodEntryController {
+
+    private final MoodEntryService moodEntryService;
+
+    /**
+     * Constructs the controller with the given service.
+     */
+    public MoodEntryController(MoodEntryService moodEntryService) {
+        this.moodEntryService = moodEntryService;
+    }
+
+    /**
+     * Creates a new mood entry for the authenticated user.
+     */
+    @PostMapping
+    public ResponseEntity<MoodEntryResponse> create(
+            @RequestBody @Valid MoodEntryRequest request,
+            Authentication authentication) {
+        Long userId = (Long) authentication.getPrincipal();
+        MoodEntryResponse response = moodEntryService.createEntry(userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * Lists all mood entries for the authenticated user.
+     */
+    @GetMapping
+    public ResponseEntity<List<MoodEntryResponse>> list(Authentication authentication) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(moodEntryService.getUserEntries(userId));
+    }
+}

--- a/backend/src/main/java/com/mindtrack/mood/dto/MoodEntryRequest.java
+++ b/backend/src/main/java/com/mindtrack/mood/dto/MoodEntryRequest.java
@@ -1,0 +1,52 @@
+package com.mindtrack.mood.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Request DTO for creating a mood entry.
+ */
+public class MoodEntryRequest {
+
+    @NotNull(message = "Mood rating is required")
+    @Min(value = 1, message = "Mood rating must be between 1 and 10")
+    @Max(value = 10, message = "Mood rating must be between 1 and 10")
+    private Integer moodRating;
+
+    private String notes;
+
+    /**
+     * Required by Jackson for request-body deserialization.
+     */
+    public MoodEntryRequest() {
+    }
+
+    /**
+     * Returns the mood rating.
+     */
+    public Integer getMoodRating() {
+        return moodRating;
+    }
+
+    /**
+     * Sets the mood rating.
+     */
+    public void setMoodRating(Integer moodRating) {
+        this.moodRating = moodRating;
+    }
+
+    /**
+     * Returns optional notes.
+     */
+    public String getNotes() {
+        return notes;
+    }
+
+    /**
+     * Sets optional notes.
+     */
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+}

--- a/backend/src/main/java/com/mindtrack/mood/dto/MoodEntryResponse.java
+++ b/backend/src/main/java/com/mindtrack/mood/dto/MoodEntryResponse.java
@@ -1,0 +1,76 @@
+package com.mindtrack.mood.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * Response DTO for mood entry data.
+ */
+public class MoodEntryResponse {
+
+    private Long id;
+    private Integer moodRating;
+    private String notes;
+    private LocalDateTime createdAt;
+
+    /**
+     * Required by Jackson for response serialization/deserialization.
+     */
+    public MoodEntryResponse() {
+    }
+
+    /**
+     * Returns the entry ID.
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * Sets the entry ID.
+     */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     * Returns the mood rating.
+     */
+    public Integer getMoodRating() {
+        return moodRating;
+    }
+
+    /**
+     * Sets the mood rating.
+     */
+    public void setMoodRating(Integer moodRating) {
+        this.moodRating = moodRating;
+    }
+
+    /**
+     * Returns optional notes.
+     */
+    public String getNotes() {
+        return notes;
+    }
+
+    /**
+     * Sets optional notes.
+     */
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    /**
+     * Returns the creation timestamp.
+     */
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    /**
+     * Sets the creation timestamp.
+     */
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/com/mindtrack/mood/model/MoodEntry.java
+++ b/backend/src/main/java/com/mindtrack/mood/model/MoodEntry.java
@@ -1,0 +1,109 @@
+package com.mindtrack.mood.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+
+/**
+ * JPA entity representing a mood entry logged by a user.
+ */
+@Entity
+@Table(name = "mood_entries")
+public class MoodEntry {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "mood_rating", nullable = false)
+    private Integer moodRating;
+
+    @Column(columnDefinition = "TEXT")
+    private String notes;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    /**
+     * Required by JPA for entity materialization.
+     */
+    public MoodEntry() {
+    }
+
+    /**
+     * Returns the entry ID.
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * Sets the entry ID.
+     */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     * Returns the user ID that owns this entry.
+     */
+    public Long getUserId() {
+        return userId;
+    }
+
+    /**
+     * Sets the user ID that owns this entry.
+     */
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    /**
+     * Returns the mood rating (1-10).
+     */
+    public Integer getMoodRating() {
+        return moodRating;
+    }
+
+    /**
+     * Sets the mood rating (1-10).
+     */
+    public void setMoodRating(Integer moodRating) {
+        this.moodRating = moodRating;
+    }
+
+    /**
+     * Returns optional notes for this mood entry.
+     */
+    public String getNotes() {
+        return notes;
+    }
+
+    /**
+     * Sets optional notes for this mood entry.
+     */
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    /**
+     * Returns the timestamp when the entry was created.
+     */
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    /**
+     * Sets the timestamp when the entry was created.
+     */
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/com/mindtrack/mood/repository/MoodEntryRepository.java
+++ b/backend/src/main/java/com/mindtrack/mood/repository/MoodEntryRepository.java
@@ -1,0 +1,16 @@
+package com.mindtrack.mood.repository;
+
+import com.mindtrack.mood.model.MoodEntry;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repository for mood entry persistence operations.
+ */
+public interface MoodEntryRepository extends JpaRepository<MoodEntry, Long> {
+
+    /**
+     * Returns all mood entries for the given user, ordered by creation time descending.
+     */
+    List<MoodEntry> findByUserIdOrderByCreatedAtDesc(Long userId);
+}

--- a/backend/src/main/java/com/mindtrack/mood/service/MoodEntryService.java
+++ b/backend/src/main/java/com/mindtrack/mood/service/MoodEntryService.java
@@ -1,0 +1,64 @@
+package com.mindtrack.mood.service;
+
+import com.mindtrack.mood.dto.MoodEntryRequest;
+import com.mindtrack.mood.dto.MoodEntryResponse;
+import com.mindtrack.mood.model.MoodEntry;
+import com.mindtrack.mood.repository.MoodEntryRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Service for mood entry creation and retrieval.
+ */
+@Service
+public class MoodEntryService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MoodEntryService.class);
+
+    private final MoodEntryRepository moodEntryRepository;
+
+    /**
+     * Constructs the service with the given repository.
+     */
+    public MoodEntryService(MoodEntryRepository moodEntryRepository) {
+        this.moodEntryRepository = moodEntryRepository;
+    }
+
+    /**
+     * Creates a new mood entry for the given user.
+     */
+    @Transactional
+    public MoodEntryResponse createEntry(Long userId, MoodEntryRequest request) {
+        MoodEntry entry = new MoodEntry();
+        entry.setUserId(userId);
+        entry.setMoodRating(request.getMoodRating());
+        entry.setNotes(request.getNotes());
+        entry.setCreatedAt(LocalDateTime.now());
+
+        MoodEntry saved = moodEntryRepository.save(entry);
+        LOG.info("Created mood entry {} for user {}", saved.getId(), userId);
+        return toResponse(saved);
+    }
+
+    /**
+     * Returns all mood entries for the given user, ordered by creation time descending.
+     */
+    public List<MoodEntryResponse> getUserEntries(Long userId) {
+        return moodEntryRepository.findByUserIdOrderByCreatedAtDesc(userId).stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    private MoodEntryResponse toResponse(MoodEntry entry) {
+        MoodEntryResponse response = new MoodEntryResponse();
+        response.setId(entry.getId());
+        response.setMoodRating(entry.getMoodRating());
+        response.setNotes(entry.getNotes());
+        response.setCreatedAt(entry.getCreatedAt());
+        return response;
+    }
+}

--- a/backend/src/main/resources/db/migration/V22__add_mood_entries_table.sql
+++ b/backend/src/main/resources/db/migration/V22__add_mood_entries_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE mood_entries (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    user_id BIGINT NOT NULL,
+    mood_rating INT NOT NULL,
+    notes TEXT,
+    created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    CONSTRAINT fk_mood_entries_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT chk_mood_rating CHECK (mood_rating BETWEEN 1 AND 10)
+);

--- a/backend/src/test/java/com/mindtrack/mood/service/MoodEntryServiceTest.java
+++ b/backend/src/test/java/com/mindtrack/mood/service/MoodEntryServiceTest.java
@@ -1,0 +1,115 @@
+package com.mindtrack.mood.service;
+
+import com.mindtrack.mood.dto.MoodEntryRequest;
+import com.mindtrack.mood.dto.MoodEntryResponse;
+import com.mindtrack.mood.model.MoodEntry;
+import com.mindtrack.mood.repository.MoodEntryRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MoodEntryServiceTest {
+
+    @Mock
+    private MoodEntryRepository moodEntryRepository;
+
+    private MoodEntryService moodEntryService;
+
+    @BeforeEach
+    void setUp() {
+        moodEntryService = new MoodEntryService(moodEntryRepository);
+    }
+
+    @Test
+    void shouldCreateEntry() {
+        MoodEntryRequest request = new MoodEntryRequest();
+        request.setMoodRating(7);
+        request.setNotes("Feeling good");
+
+        when(moodEntryRepository.save(any(MoodEntry.class))).thenAnswer(invocation -> {
+            MoodEntry saved = invocation.getArgument(0);
+            saved.setId(1L);
+            return saved;
+        });
+
+        MoodEntryResponse result = moodEntryService.createEntry(1L, request);
+
+        assertNotNull(result);
+        assertEquals(1L, result.getId());
+        assertEquals(7, result.getMoodRating());
+        assertEquals("Feeling good", result.getNotes());
+        assertNotNull(result.getCreatedAt());
+
+        ArgumentCaptor<MoodEntry> captor = ArgumentCaptor.forClass(MoodEntry.class);
+        verify(moodEntryRepository).save(captor.capture());
+        assertEquals(1L, captor.getValue().getUserId());
+        assertEquals(7, captor.getValue().getMoodRating());
+    }
+
+    @Test
+    void shouldCreateEntryWithNullNotes() {
+        MoodEntryRequest request = new MoodEntryRequest();
+        request.setMoodRating(5);
+        request.setNotes(null);
+
+        when(moodEntryRepository.save(any(MoodEntry.class))).thenAnswer(invocation -> {
+            MoodEntry saved = invocation.getArgument(0);
+            saved.setId(2L);
+            return saved;
+        });
+
+        MoodEntryResponse result = moodEntryService.createEntry(1L, request);
+
+        assertNotNull(result);
+        assertEquals(5, result.getMoodRating());
+        assertNull(result.getNotes());
+    }
+
+    @Test
+    void shouldReturnEntriesForUser() {
+        MoodEntry entry1 = createEntry(1L, 8, "Great day");
+        MoodEntry entry2 = createEntry(2L, 3, "Tough day");
+        when(moodEntryRepository.findByUserIdOrderByCreatedAtDesc(1L))
+                .thenReturn(List.of(entry1, entry2));
+
+        List<MoodEntryResponse> results = moodEntryService.getUserEntries(1L);
+
+        assertEquals(2, results.size());
+        assertEquals(8, results.get(0).getMoodRating());
+        assertEquals(3, results.get(1).getMoodRating());
+    }
+
+    @Test
+    void shouldReturnEmptyListForUserWithNoEntries() {
+        when(moodEntryRepository.findByUserIdOrderByCreatedAtDesc(1L))
+                .thenReturn(List.of());
+
+        List<MoodEntryResponse> results = moodEntryService.getUserEntries(1L);
+
+        assertNotNull(results);
+        assertEquals(0, results.size());
+    }
+
+    private MoodEntry createEntry(Long id, int rating, String notes) {
+        MoodEntry entry = new MoodEntry();
+        entry.setId(id);
+        entry.setUserId(1L);
+        entry.setMoodRating(rating);
+        entry.setNotes(notes);
+        entry.setCreatedAt(LocalDateTime.now());
+        return entry;
+    }
+}

--- a/frontend/src/components/dashboard/MoodEntryWidget.vue
+++ b/frontend/src/components/dashboard/MoodEntryWidget.vue
@@ -1,0 +1,166 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import api from '@/services/api'
+
+const selectedMood = ref<number | null>(null)
+const notes = ref('')
+const submitting = ref(false)
+const submitted = ref(false)
+const error = ref<string | null>(null)
+
+const moodEmojis = [
+  { value: 1, emoji: '😞', label: 'Very bad' },
+  { value: 2, emoji: '😟', label: 'Bad' },
+  { value: 3, emoji: '😕', label: 'Poor' },
+  { value: 4, emoji: '😐', label: 'Below average' },
+  { value: 5, emoji: '🙂', label: 'Okay' },
+  { value: 6, emoji: '😊', label: 'Good' },
+  { value: 7, emoji: '😄', label: 'Pretty good' },
+  { value: 8, emoji: '😁', label: 'Great' },
+  { value: 9, emoji: '🤩', label: 'Excellent' },
+  { value: 10, emoji: '🥳', label: 'Amazing' },
+]
+
+async function submitMood() {
+  if (!selectedMood.value) return
+  submitting.value = true
+  error.value = null
+  try {
+    await api.post('/mood', { moodRating: selectedMood.value, notes: notes.value || null })
+    submitted.value = true
+  } catch {
+    error.value = 'Failed to save mood. Please try again.'
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <section class="mood-widget">
+    <h2 class="widget-title">How are you feeling?</h2>
+    <div v-if="submitted" class="submitted-state">
+      <span class="submitted-emoji">{{
+        moodEmojis.find((m) => m.value === selectedMood)?.emoji
+      }}</span>
+      <p class="submitted-text">Mood logged! Keep it up.</p>
+    </div>
+    <div v-else>
+      <div v-if="error" class="error-msg">{{ error }}</div>
+      <div class="emoji-grid">
+        <button
+          v-for="m in moodEmojis"
+          :key="m.value"
+          :class="['emoji-btn', { selected: selectedMood === m.value }]"
+          :title="m.label"
+          :aria-label="m.label"
+          type="button"
+          @click="selectedMood = m.value"
+        >
+          {{ m.emoji }}
+        </button>
+      </div>
+      <textarea
+        v-if="selectedMood"
+        v-model="notes"
+        class="notes-input"
+        placeholder="Optional notes..."
+        rows="2"
+      />
+      <button class="btn btn-primary" :disabled="!selectedMood || submitting" @click="submitMood">
+        {{ submitting ? 'Saving...' : 'Log mood' }}
+      </button>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.mood-widget {
+  background: var(--color-white);
+  border: 1px solid var(--color-gray-200);
+  border-radius: var(--border-radius-lg);
+  padding: var(--space-5);
+  margin-bottom: var(--space-6);
+}
+.widget-title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-gray-900);
+  margin: 0 0 var(--space-4) 0;
+}
+.emoji-grid {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  margin-bottom: var(--space-3);
+}
+.emoji-btn {
+  font-size: 1.5rem;
+  background: var(--color-gray-50);
+  border: 2px solid transparent;
+  border-radius: var(--border-radius);
+  padding: var(--space-2);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.emoji-btn:hover {
+  border-color: var(--color-primary-50);
+  background: var(--color-gray-100);
+}
+.emoji-btn.selected {
+  border-color: var(--color-primary);
+  background: #ede9fe;
+}
+.notes-input {
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--border-radius);
+  font-size: var(--font-size-sm);
+  resize: vertical;
+  margin-bottom: var(--space-3);
+  box-sizing: border-box;
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--border-radius);
+  font-weight: var(--font-weight-medium);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  border: none;
+}
+.btn-primary {
+  background: var(--color-primary);
+  color: var(--color-white);
+}
+.btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.submitted-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-4) 0;
+}
+.submitted-emoji {
+  font-size: 2rem;
+}
+.submitted-text {
+  color: var(--color-gray-600);
+  margin: 0;
+  font-size: var(--font-size-sm);
+}
+.error-msg {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: var(--color-error);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--border-radius);
+  margin-bottom: var(--space-3);
+  font-size: var(--font-size-sm);
+}
+</style>

--- a/frontend/src/components/dashboard/__tests__/MoodEntryWidget.test.ts
+++ b/frontend/src/components/dashboard/__tests__/MoodEntryWidget.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import MoodEntryWidget from '../MoodEntryWidget.vue'
+
+vi.mock('@/services/api', () => ({
+  default: {
+    post: vi.fn(),
+  },
+}))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: vi.fn(() => ({ logout: vi.fn() })),
+}))
+
+vi.mock('@/router', () => ({
+  default: { push: vi.fn() },
+}))
+
+vi.mock('@/composables/useErrorHandler', () => ({
+  useErrorHandler: vi.fn(() => ({ addError: vi.fn() })),
+}))
+
+describe('MoodEntryWidget', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the widget title', () => {
+    const wrapper = mount(MoodEntryWidget)
+    expect(wrapper.find('.widget-title').text()).toBe('How are you feeling?')
+  })
+
+  it('renders 10 emoji buttons', () => {
+    const wrapper = mount(MoodEntryWidget)
+    const buttons = wrapper.findAll('.emoji-btn')
+    expect(buttons).toHaveLength(10)
+  })
+
+  it('log mood button is disabled when no mood is selected', () => {
+    const wrapper = mount(MoodEntryWidget)
+    const submitBtn = wrapper.find('.btn-primary')
+    expect(submitBtn.attributes('disabled')).toBeDefined()
+  })
+
+  it('selects a mood when an emoji button is clicked', async () => {
+    const wrapper = mount(MoodEntryWidget)
+    const buttons = wrapper.findAll('.emoji-btn')
+    await buttons[4].trigger('click')
+    expect(buttons[4].classes()).toContain('selected')
+  })
+
+  it('shows textarea after mood is selected', async () => {
+    const wrapper = mount(MoodEntryWidget)
+    expect(wrapper.find('.notes-input').exists()).toBe(false)
+    const buttons = wrapper.findAll('.emoji-btn')
+    await buttons[0].trigger('click')
+    expect(wrapper.find('.notes-input').exists()).toBe(true)
+  })
+
+  it('enables log mood button after mood is selected', async () => {
+    const wrapper = mount(MoodEntryWidget)
+    const buttons = wrapper.findAll('.emoji-btn')
+    await buttons[2].trigger('click')
+    const submitBtn = wrapper.find('.btn-primary')
+    expect(submitBtn.attributes('disabled')).toBeUndefined()
+  })
+
+  it('shows submitted state after successful submission', async () => {
+    const api = await import('@/services/api')
+    vi.mocked(api.default.post).mockResolvedValueOnce({})
+
+    const wrapper = mount(MoodEntryWidget)
+    const buttons = wrapper.findAll('.emoji-btn')
+    await buttons[6].trigger('click')
+    await wrapper.find('.btn-primary').trigger('click')
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('.submitted-state').exists()).toBe(true)
+    expect(wrapper.find('.submitted-text').text()).toBe('Mood logged! Keep it up.')
+  })
+
+  it('shows error message on submission failure', async () => {
+    const api = await import('@/services/api')
+    vi.mocked(api.default.post).mockRejectedValueOnce(new Error('Network error'))
+
+    const wrapper = mount(MoodEntryWidget)
+    const buttons = wrapper.findAll('.emoji-btn')
+    await buttons[0].trigger('click')
+    await wrapper.find('.btn-primary').trigger('click')
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('.error-msg').exists()).toBe(true)
+    expect(wrapper.find('.error-msg').text()).toBe('Failed to save mood. Please try again.')
+  })
+})

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -10,6 +10,7 @@ import GoalProgressChart from '@/components/charts/GoalProgressChart.vue'
 import TutorialOverlay from '@/components/tutorial/TutorialOverlay.vue'
 import ActiveGoalsWidget from '@/components/dashboard/ActiveGoalsWidget.vue'
 import DailyTipWidget from '@/components/dashboard/DailyTipWidget.vue'
+import MoodEntryWidget from '@/components/dashboard/MoodEntryWidget.vue'
 import ResourcesWidget from '@/components/dashboard/ResourcesWidget.vue'
 import WellbeingWidget from '@/components/dashboard/WellbeingWidget.vue'
 
@@ -194,6 +195,9 @@ watch(
           <span class="vcard-label">Pending Review</span>
         </div>
       </div>
+
+      <!-- Mood Entry -->
+      <MoodEntryWidget />
 
       <!-- Active Goals -->
       <div v-if="goalsStore.loading" class="goals-loading">Loading goals...</div>


### PR DESCRIPTION
## Summary
- New Flyway migration `V22__add_mood_entries_table.sql` — `mood_entries(id, user_id, mood_rating 1–10, notes, created_at)` with user FK cascade-delete
- New `mood` module: entity, repository, request/response DTOs, service, and REST controller (`POST /api/mood`, `GET /api/mood`)
- New `MoodEntryWidget.vue` — 10-emoji mood picker with optional notes field and success/error state; added to dashboard between validation cards and Active Goals

Closes #271