### PR TITLE
chore(security): fix jackson-core SNYK-JAVA-COMFASTERXMLJACKSONCORE-15365924

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -64,12 +64,4 @@ ignore:
           No fix available in spring-security-core 6.5.1 (latest managed by
           Spring Boot 3.5.3). Revisit when Spring Security releases a patch.
         expires: '2026-05-28T00:00:00.000Z'
-  SNYK-JAVA-COMFASTERXMLJACKSONCORE-15365924:
-    - '*':
-        reason: >-
-          Fixed in jackson-core 2.18.6 and 2.21.1. Current dependency path
-          resolves jackson-core 2.20.2 via spring-boot-jackson2 4.0.3 with no
-          direct Snyk upgrade path from this project. Revisit when Spring Boot
-          manages jackson-core 2.21.1+ or a safe dependency override is validated.
-        expires: '2026-06-17T00:00:00.000Z'
 patch: {}

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
## Summary
- Upgraded `spring-boot-starter-parent` from `4.0.3` to `4.0.4`.
- This upgrades `spring-boot-jackson2` transitively to `4.0.4` and moves Jackson 2.x to `2.21.1` (including `jackson-core`).
- Removed the temporary `.snyk` ignore for `SNYK-JAVA-COMFASTERXMLJACKSONCORE-15365924`.

## Verification
- `mvn -f backend/pom.xml dependency:tree -Dincludes=com.fasterxml.jackson.core:jackson-core -DoutputType=text -DskipTests`
  - resolved path now: `spring-boot-jackson2:4.0.4 -> jackson-databind:2.21.1 -> jackson-core:2.21.1`
- `mvn -f backend/pom.xml clean verify` (469 tests, 0 failures)
- `snyk test --file=backend/pom.xml --severity-threshold=high --policy-path=.snyk`
- `snyk test --file=frontend/package.json --severity-threshold=high --policy-path=.snyk`

Closes #289
Closes #290
