### PR TITLE
fix(security): remediate whatsapp webhook ssrf flow

### DIFF
--- a/backend/src/main/java/com/mindtrack/messaging/service/MessagingService.java
+++ b/backend/src/main/java/com/mindtrack/messaging/service/MessagingService.java
@@ -163,23 +163,22 @@ public class MessagingService {
                 .filter(profile -> phoneNumber.equals(profile.getWhatsappNumber()))
                 .findFirst();
         if (profileOpt.isEmpty()) {
-            service.sendMessage(phoneNumber,
-                    "Your WhatsApp number is not linked to MindTrack. "
-                            + "Please add your number in your profile settings.");
+            LOG.warn("Ignoring WhatsApp message from unlinked phone={}", phoneNumber);
             return;
         }
 
         Long userId = profileOpt.get().getUserId();
+        String linkedWhatsappNumber = profileOpt.get().getWhatsappNumber();
 
         try {
             ChatRequest chatRequest = new ChatRequest(null, text, ConversationType.QUICK_CHECKIN);
             ChatResponse response = conversationService.chatWithChannel(
                     userId, chatRequest, Channel.WHATSAPP);
 
-            service.sendMessage(phoneNumber, response.content());
+            service.sendMessage(linkedWhatsappNumber, response.content());
         } catch (Exception e) {
             LOG.error("Error processing WhatsApp message from phone={}", phoneNumber, e);
-            service.sendMessage(phoneNumber,
+            service.sendMessage(linkedWhatsappNumber,
                     "Sorry, I encountered an error processing your message. Please try again later.");
         }
     }

--- a/backend/src/test/java/com/mindtrack/messaging/service/MessagingServiceTest.java
+++ b/backend/src/test/java/com/mindtrack/messaging/service/MessagingServiceTest.java
@@ -135,13 +135,13 @@ class MessagingServiceTest {
     }
 
     @Test
-    void shouldReplyUnlinkedForUnknownWhatsAppNumber() {
+    void shouldIgnoreUnknownWhatsAppNumber() {
         WhatsAppWebhook webhook = createWhatsAppWebhook("+9999999999", "Hello");
         when(userProfileRepository.findAllByWhatsappNumberNotNull()).thenReturn(List.of());
 
         messagingService.handleWhatsAppMessage(webhook);
 
-        verify(whatsAppService).sendMessage(eq("+9999999999"), any(String.class));
+        verify(whatsAppService, never()).sendMessage(any(), any());
         verify(conversationService, never()).chatWithChannel(any(), any(), any());
     }
 


### PR DESCRIPTION
## Summary
Remediates the WhatsApp webhook SSRF data flow by ensuring outbound sends never use untrusted inbound phone values.

## Changes
- Ignore inbound WhatsApp messages from unlinked phone numbers (no outbound response to untrusted sender values).
- For linked users, always send WhatsApp responses to the persisted linked profile number.
- Updated `MessagingServiceTest` to assert unknown numbers are ignored.

## Validation
- `mvn -f backend/pom.xml -Dtest=MessagingServiceTest test`
- `snyk code test --severity-threshold=high` (0 issues)

Closes #294
