### PR TITLE
fix(onboarding): set createdAt for suggested milestones

### DIFF
--- a/backend/src/main/java/com/mindtrack/onboarding/service/OnboardingService.java
+++ b/backend/src/main/java/com/mindtrack/onboarding/service/OnboardingService.java
@@ -103,6 +103,7 @@ public class OnboardingService {
         for (var template : milestoneTemplateRegistry.getTemplates(goal.getCategory())) {
             var milestone = new Milestone();
             milestone.setGoal(goal);
+            milestone.setCreatedAt(LocalDateTime.now());
             milestone.setTitle(template.title());
             milestone.setNotes(template.notes());
             milestone.setTargetDate(LocalDate.now().plusDays(template.daysOffset()));

--- a/backend/src/test/java/com/mindtrack/onboarding/service/OnboardingServiceTest.java
+++ b/backend/src/test/java/com/mindtrack/onboarding/service/OnboardingServiceTest.java
@@ -12,13 +12,16 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -179,5 +182,26 @@ class OnboardingServiceTest {
         var goals = onboardingService.generateGoalsFromSurvey(1L, request);
 
         assertTrue(goals.size() >= 2);
+    }
+
+    @Test
+    void shouldSetCreatedAtOnSuggestedMilestones() {
+        SurveyRequest request = new SurveyRequest();
+        request.setMoodBaseline(5);
+
+        when(goalRepository.save(any())).thenAnswer(inv -> {
+            var g = inv.getArgument(0, com.mindtrack.goals.model.Goal.class);
+            g.setId(1L);
+            return g;
+        });
+
+        onboardingService.generateGoalsFromSurvey(1L, request);
+
+        ArgumentCaptor<Milestone> milestoneCaptor = ArgumentCaptor.forClass(Milestone.class);
+        verify(milestoneRepository, atLeastOnce()).save(milestoneCaptor.capture());
+        milestoneCaptor.getAllValues().forEach(milestone -> {
+            assertNotNull(milestone.getCreatedAt());
+            assertTrue(milestone.isSuggested());
+        });
     }
 }


### PR DESCRIPTION
## Summary
- set `createdAt` when creating onboarding suggested milestones before persistence
- prevent `created_at` null inserts for milestone rows
- add regression test to assert suggested milestones persist with non-null `createdAt`

## Validation
- `cd backend && mvn clean test -Dtest=OnboardingServiceTest,GoalServiceTest -DfailIfNoTests=false`

Closes #308
