### PR TITLE
fix(common): relax API rate limits

### DIFF
--- a/backend/src/main/java/com/mindtrack/common/config/RateLimitInterceptor.java
+++ b/backend/src/main/java/com/mindtrack/common/config/RateLimitInterceptor.java
@@ -10,14 +10,14 @@ import org.springframework.web.servlet.HandlerInterceptor;
 
 /**
  * Fixed-window per-user rate limiter.
- * General endpoints: 60 requests per minute.
- * AI endpoints (/api/ai/**): 10 requests per minute.
+ * General endpoints: 120 requests per minute.
+ * AI endpoints (/api/ai/**): 20 requests per minute.
  */
 public class RateLimitInterceptor implements HandlerInterceptor {
 
     private static final int WINDOW_MS = 60_000;
-    private static final int GENERAL_LIMIT = 60;
-    private static final int AI_LIMIT = 10;
+    private static final int GENERAL_LIMIT = 120;
+    private static final int AI_LIMIT = 20;
 
     /** [0] = window start timestamp, [1] = count in current window. */
     private final ConcurrentHashMap<String, long[]> generalCounters = new ConcurrentHashMap<>();

--- a/backend/src/test/java/com/mindtrack/common/config/RateLimitInterceptorTest.java
+++ b/backend/src/test/java/com/mindtrack/common/config/RateLimitInterceptorTest.java
@@ -32,7 +32,7 @@ class RateLimitInterceptorTest {
     @Test
     void allowsRequestsUnderGeneralLimit() throws Exception {
         MockHttpServletRequest req = new MockHttpServletRequest("GET", "/api/interviews");
-        for (int i = 0; i < 60; i++) {
+        for (int i = 0; i < 120; i++) {
             MockHttpServletResponse resp = new MockHttpServletResponse();
             boolean result = interceptor.preHandle(req, resp, null);
             assertThat(result).isTrue();
@@ -42,7 +42,7 @@ class RateLimitInterceptorTest {
     @Test
     void blocksRequestsOverGeneralLimit() throws Exception {
         MockHttpServletRequest req = new MockHttpServletRequest("GET", "/api/interviews");
-        for (int i = 0; i < 60; i++) {
+        for (int i = 0; i < 120; i++) {
             interceptor.preHandle(req, new MockHttpServletResponse(), null);
         }
         MockHttpServletResponse resp = new MockHttpServletResponse();
@@ -54,7 +54,7 @@ class RateLimitInterceptorTest {
     @Test
     void aiEndpointHasLowerLimit() throws Exception {
         MockHttpServletRequest req = new MockHttpServletRequest("POST", "/api/ai/chat");
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 20; i++) {
             interceptor.preHandle(req, new MockHttpServletResponse(), null);
         }
         MockHttpServletResponse resp = new MockHttpServletResponse();

--- a/infra/modules/api-gateway/main.tf
+++ b/infra/modules/api-gateway/main.tf
@@ -36,8 +36,8 @@ resource "aws_apigatewayv2_stage" "default" {
   auto_deploy = true
 
   default_route_settings {
-    throttling_burst_limit = 200
-    throttling_rate_limit  = 50
+    throttling_burst_limit = 400
+    throttling_rate_limit  = 100
   }
 
   access_log_settings {


### PR DESCRIPTION
## Summary
- double the backend per-user rate limits for general API requests and AI requests
- double the API Gateway default stage throttling settings so infra and app limits stay aligned
- update the rate limiter test thresholds to match the new request budgets

## Testing
- mvn clean verify
- npm run test:unit
- bash infra/tests/unit/validate.sh

Closes #316
