### PR TITLE
feat(appointments): notify patients on booking

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -108,6 +108,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
 
         <!-- Database -->
         <dependency>

--- a/backend/src/main/java/com/mindtrack/appointment/service/AppointmentNotificationService.java
+++ b/backend/src/main/java/com/mindtrack/appointment/service/AppointmentNotificationService.java
@@ -1,0 +1,169 @@
+package com.mindtrack.appointment.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mindtrack.appointment.model.Appointment;
+import com.mindtrack.common.model.User;
+import com.mindtrack.messaging.service.TelegramService;
+import com.mindtrack.messaging.service.WhatsAppService;
+import com.mindtrack.profile.model.UserProfile;
+import com.mindtrack.profile.repository.UserProfileRepository;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.lang.Nullable;
+import org.springframework.mail.MailException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/**
+ * Sends patient-facing notifications after appointments are booked.
+ */
+@Service
+public class AppointmentNotificationService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AppointmentNotificationService.class);
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() { };
+    private static final DateTimeFormatter DATE_TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("EEE, MMM d yyyy 'at' HH:mm");
+
+    private final UserProfileRepository userProfileRepository;
+    private final ObjectMapper objectMapper;
+    private final TelegramService telegramService;
+    @Nullable
+    private final WhatsAppService whatsAppService;
+    @Nullable
+    private final JavaMailSender mailSender;
+
+    public AppointmentNotificationService(UserProfileRepository userProfileRepository,
+                                          ObjectMapper objectMapper,
+                                          TelegramService telegramService,
+                                          Optional<WhatsAppService> whatsAppService,
+                                          Optional<JavaMailSender> mailSender) {
+        this.userProfileRepository = userProfileRepository;
+        this.objectMapper = objectMapper;
+        this.telegramService = telegramService;
+        this.whatsAppService = whatsAppService.orElse(null);
+        this.mailSender = mailSender.orElse(null);
+    }
+
+    /**
+     * Notifies a patient after their therapist books an appointment.
+     */
+    public void notifyPatientAboutBooking(Appointment appointment, User therapist, User patient) {
+        UserProfile profile = userProfileRepository.findByUserId(patient.getId()).orElse(null);
+        NotificationPreferences preferences = resolvePreferences(profile);
+        String message = buildMessage(appointment, therapist);
+
+        if (preferences.pushEnabled()) {
+            sendPushNotification(profile, patient.getId(), message);
+        }
+        if (preferences.emailEnabled()) {
+            sendEmail(patient, therapist, message);
+        }
+    }
+
+    private NotificationPreferences resolvePreferences(@Nullable UserProfile profile) {
+        if (profile == null || !StringUtils.hasText(profile.getNotificationPrefs())) {
+            return new NotificationPreferences(true, false);
+        }
+
+        try {
+            Map<String, Object> preferences = objectMapper.readValue(profile.getNotificationPrefs(), MAP_TYPE);
+            return new NotificationPreferences(
+                    asBoolean(preferences.get("emailNotifications")),
+                    asBoolean(preferences.get("pushNotifications")));
+        } catch (Exception ex) {
+            LOG.warn("Failed to parse notification prefs for userId={}: {}", profile.getUserId(), ex.getMessage());
+            return new NotificationPreferences(true, false);
+        }
+    }
+
+    private boolean asBoolean(@Nullable Object value) {
+        if (value instanceof Boolean booleanValue) {
+            return booleanValue;
+        }
+        if (value instanceof String stringValue) {
+            return Boolean.parseBoolean(stringValue);
+        }
+        return false;
+    }
+
+    private void sendPushNotification(@Nullable UserProfile profile, Long patientId, String message) {
+        if (profile == null) {
+            LOG.info("Skipping appointment push notification for patientId={} because no profile exists", patientId);
+            return;
+        }
+
+        if (StringUtils.hasText(profile.getTelegramChatId())) {
+            telegramService.sendMessage(profile.getTelegramChatId(), message);
+            LOG.info("Sent appointment Telegram notification to patientId={}", patientId);
+            return;
+        }
+
+        if (StringUtils.hasText(profile.getWhatsappNumber())) {
+            if (whatsAppService == null) {
+                LOG.warn("Skipping appointment WhatsApp notification for patientId={} because WhatsApp is disabled",
+                        patientId);
+                return;
+            }
+            whatsAppService.sendMessage(profile.getWhatsappNumber(), message);
+            LOG.info("Sent appointment WhatsApp notification to patientId={}", patientId);
+            return;
+        }
+
+        LOG.info("Skipping appointment push notification for patientId={} because no linked channel exists",
+                patientId);
+    }
+
+    private void sendEmail(User patient, User therapist, String message) {
+        if (mailSender == null) {
+            LOG.warn("Skipping appointment email notification for patientId={} because mail is not configured",
+                    patient.getId());
+            return;
+        }
+        if (!StringUtils.hasText(patient.getEmail())) {
+            LOG.warn("Skipping appointment email notification for patientId={} because no email exists",
+                    patient.getId());
+            return;
+        }
+
+        SimpleMailMessage mailMessage = new SimpleMailMessage();
+        mailMessage.setTo(patient.getEmail());
+        mailMessage.setSubject("New MindTrack appointment with " + displayName(therapist));
+        mailMessage.setText(message);
+
+        try {
+            mailSender.send(mailMessage);
+            LOG.info("Sent appointment email notification to patientId={}", patient.getId());
+        } catch (MailException ex) {
+            LOG.warn("Failed to send appointment email notification to patientId={}: {}",
+                    patient.getId(), ex.getMessage());
+        }
+    }
+
+    private String buildMessage(Appointment appointment, User therapist) {
+        return "Your therapist " + displayName(therapist) + " booked a new appointment for "
+                + appointment.getStartAt().format(DATE_TIME_FORMATTER) + ".\n"
+                + "Ends at " + appointment.getEndAt().format(DateTimeFormatter.ofPattern("HH:mm")) + ".\n"
+                + "Reason: " + defaultText(appointment.getReason(), "No reason provided") + ".";
+    }
+
+    private String displayName(User user) {
+        if (StringUtils.hasText(user.getName())) {
+            return user.getName().trim();
+        }
+        return user.getEmail();
+    }
+
+    private String defaultText(@Nullable String value, String fallback) {
+        return StringUtils.hasText(value) ? value.trim() : fallback;
+    }
+
+    private record NotificationPreferences(boolean emailEnabled, boolean pushEnabled) {
+    }
+}

--- a/backend/src/main/java/com/mindtrack/appointment/service/AppointmentService.java
+++ b/backend/src/main/java/com/mindtrack/appointment/service/AppointmentService.java
@@ -28,15 +28,18 @@ public class AppointmentService {
     private final TherapistPatientRepository therapistPatientRepository;
     private final UserRepository userRepository;
     private final AppointmentMapper appointmentMapper;
+    private final AppointmentNotificationService appointmentNotificationService;
 
     public AppointmentService(AppointmentRepository appointmentRepository,
                               TherapistPatientRepository therapistPatientRepository,
                               UserRepository userRepository,
-                              AppointmentMapper appointmentMapper) {
+                              AppointmentMapper appointmentMapper,
+                              AppointmentNotificationService appointmentNotificationService) {
         this.appointmentRepository = appointmentRepository;
         this.therapistPatientRepository = therapistPatientRepository;
         this.userRepository = userRepository;
         this.appointmentMapper = appointmentMapper;
+        this.appointmentNotificationService = appointmentNotificationService;
     }
 
     /**
@@ -70,8 +73,13 @@ public class AppointmentService {
         appointment.setReason(request.getReason());
         appointment.setNotes(request.getNotes());
 
+        User patient = loadUser(patientId, PATIENT_NOT_FOUND_PREFIX);
         Appointment saved = appointmentRepository.save(appointment);
-        return appointmentMapper.toResponse(saved, loadPatient(patientId));
+        appointmentNotificationService.notifyPatientAboutBooking(
+                saved,
+                loadUser(therapistId, "Therapist not found: "),
+                patient);
+        return appointmentMapper.toResponse(saved, patient);
     }
 
     private void validateRelationship(Long therapistId, Long patientId) {
@@ -112,7 +120,11 @@ public class AppointmentService {
     }
 
     private User loadPatient(Long patientId) {
-        return userRepository.findById(patientId)
-                .orElseThrow(() -> new IllegalArgumentException(PATIENT_NOT_FOUND_PREFIX + patientId));
+        return loadUser(patientId, PATIENT_NOT_FOUND_PREFIX);
+    }
+
+    private User loadUser(Long userId, String notFoundPrefix) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException(notFoundPrefix + userId));
     }
 }

--- a/backend/src/test/java/com/mindtrack/appointment/service/AppointmentNotificationServiceTest.java
+++ b/backend/src/test/java/com/mindtrack/appointment/service/AppointmentNotificationServiceTest.java
@@ -1,0 +1,129 @@
+package com.mindtrack.appointment.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mindtrack.appointment.model.Appointment;
+import com.mindtrack.common.model.User;
+import com.mindtrack.messaging.service.TelegramService;
+import com.mindtrack.messaging.service.WhatsAppService;
+import com.mindtrack.profile.model.UserProfile;
+import com.mindtrack.profile.repository.UserProfileRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AppointmentNotificationServiceTest {
+
+    @Mock
+    private UserProfileRepository userProfileRepository;
+    @Mock
+    private TelegramService telegramService;
+    @Mock
+    private WhatsAppService whatsAppService;
+    @Mock
+    private JavaMailSender mailSender;
+
+    private AppointmentNotificationService appointmentNotificationService;
+
+    @BeforeEach
+    void setUp() {
+        appointmentNotificationService = new AppointmentNotificationService(
+                userProfileRepository,
+                new ObjectMapper(),
+                telegramService,
+                Optional.of(whatsAppService),
+                Optional.of(mailSender));
+    }
+
+    @Test
+    void shouldSendEmailWhenEmailNotificationsEnabled() {
+        when(userProfileRepository.findByUserId(10L)).thenReturn(Optional.of(createProfile(
+                10L, "{\"emailNotifications\":true,\"pushNotifications\":false}", null, null)));
+
+        appointmentNotificationService.notifyPatientAboutBooking(
+                createAppointment(),
+                createUser(3L, "Dr. Lane", "therapist@test.com"),
+                createUser(10L, "Patient One", "patient@test.com"));
+
+        ArgumentCaptor<SimpleMailMessage> mailCaptor = ArgumentCaptor.forClass(SimpleMailMessage.class);
+        verify(mailSender).send(mailCaptor.capture());
+        assertEquals("patient@test.com", mailCaptor.getValue().getTo()[0]);
+        assertEquals("New MindTrack appointment with Dr. Lane", mailCaptor.getValue().getSubject());
+        assertTrue(mailCaptor.getValue().getText().contains("Weekly check-in"));
+        verify(telegramService, never()).sendMessage(org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void shouldSendTelegramWhenPushNotificationsEnabled() {
+        when(userProfileRepository.findByUserId(10L)).thenReturn(Optional.of(createProfile(
+                10L, "{\"emailNotifications\":false,\"pushNotifications\":true}", "123456", null)));
+
+        appointmentNotificationService.notifyPatientAboutBooking(
+                createAppointment(),
+                createUser(3L, "Dr. Lane", "therapist@test.com"),
+                createUser(10L, "Patient One", "patient@test.com"));
+
+        verify(telegramService).sendMessage(org.mockito.ArgumentMatchers.eq("123456"),
+                org.mockito.ArgumentMatchers.contains("Dr. Lane"));
+        verify(mailSender, never()).send(org.mockito.ArgumentMatchers.any(SimpleMailMessage.class));
+    }
+
+    @Test
+    void shouldFallBackToWhatsAppWhenTelegramIsUnavailable() {
+        when(userProfileRepository.findByUserId(10L)).thenReturn(Optional.of(createProfile(
+                10L, "{\"emailNotifications\":false,\"pushNotifications\":true}", null, "+1234567890")));
+
+        appointmentNotificationService.notifyPatientAboutBooking(
+                createAppointment(),
+                createUser(3L, "Dr. Lane", "therapist@test.com"),
+                createUser(10L, "Patient One", "patient@test.com"));
+
+        verify(whatsAppService).sendMessage(org.mockito.ArgumentMatchers.eq("+1234567890"),
+                org.mockito.ArgumentMatchers.contains("Weekly check-in"));
+        verify(telegramService, never()).sendMessage(org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyString());
+    }
+
+    private Appointment createAppointment() {
+        Appointment appointment = new Appointment();
+        appointment.setId(5L);
+        appointment.setTherapistId(3L);
+        appointment.setPatientId(10L);
+        appointment.setStartAt(LocalDateTime.of(2026, 4, 20, 10, 0));
+        appointment.setEndAt(LocalDateTime.of(2026, 4, 20, 10, 50));
+        appointment.setReason("Weekly check-in");
+        return appointment;
+    }
+
+    private User createUser(Long id, String name, String email) {
+        User user = new User();
+        user.setId(id);
+        user.setName(name);
+        user.setEmail(email);
+        return user;
+    }
+
+    private UserProfile createProfile(Long userId, String notificationPrefs,
+                                      String telegramChatId, String whatsappNumber) {
+        UserProfile profile = new UserProfile();
+        profile.setUserId(userId);
+        profile.setNotificationPrefs(notificationPrefs);
+        profile.setTelegramChatId(telegramChatId);
+        profile.setWhatsappNumber(whatsappNumber);
+        return profile;
+    }
+}

--- a/backend/src/test/java/com/mindtrack/appointment/service/AppointmentServiceTest.java
+++ b/backend/src/test/java/com/mindtrack/appointment/service/AppointmentServiceTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,6 +35,8 @@ class AppointmentServiceTest {
     private TherapistPatientRepository therapistPatientRepository;
     @Mock
     private UserRepository userRepository;
+    @Mock
+    private AppointmentNotificationService appointmentNotificationService;
 
     private AppointmentService appointmentService;
 
@@ -41,7 +44,7 @@ class AppointmentServiceTest {
     void setUp() {
         appointmentService = new AppointmentService(
                 appointmentRepository, therapistPatientRepository, userRepository,
-                new AppointmentMapper());
+                new AppointmentMapper(), appointmentNotificationService);
     }
 
     @Test
@@ -74,6 +77,7 @@ class AppointmentServiceTest {
         when(appointmentRepository.findByPatientIdAndStatusInAndStartAtLessThanAndEndAtGreaterThan(
                 any(), any(), any(), any())).thenReturn(List.of());
         when(userRepository.findById(10L)).thenReturn(Optional.of(createUser(10L, "Patient A")));
+        when(userRepository.findById(3L)).thenReturn(Optional.of(createUser(3L, "Therapist A")));
         when(appointmentRepository.save(any(Appointment.class))).thenAnswer(inv -> {
             Appointment appointment = inv.getArgument(0);
             appointment.setId(99L);
@@ -92,6 +96,7 @@ class AppointmentServiceTest {
         assertEquals(99L, result.getId());
         assertEquals(AppointmentStatus.SCHEDULED, result.getStatus());
         assertEquals("Weekly check-in", result.getReason());
+        verify(appointmentNotificationService).notifyPatientAboutBooking(any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- notify patients when a therapist books an appointment
- honor email and push preferences from the patient profile
- reuse linked Telegram or WhatsApp channels for push-style delivery and email when enabled

## Testing
- mvn -Dtest=AppointmentServiceTest,AppointmentNotificationServiceTest,AppointmentControllerTest test

Closes #323