### PR TITLE
feat(appointments): support cancellations for both roles

### DIFF
--- a/backend/src/main/java/com/mindtrack/appointment/controller/AppointmentController.java
+++ b/backend/src/main/java/com/mindtrack/appointment/controller/AppointmentController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -50,5 +51,15 @@ public class AppointmentController {
         Long therapistId = (Long) authentication.getPrincipal();
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(appointmentService.bookAppointment(therapistId, patientId, request));
+    }
+
+    /**
+     * Cancels an appointment that belongs to the authenticated therapist.
+     */
+    @PatchMapping("/appointments/{appointmentId}/cancel")
+    public ResponseEntity<AppointmentResponse> cancelAppointment(@PathVariable Long appointmentId,
+                                                                 Authentication authentication) {
+        Long therapistId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(appointmentService.cancelAppointmentAsTherapist(therapistId, appointmentId));
     }
 }

--- a/backend/src/main/java/com/mindtrack/appointment/controller/PatientAppointmentController.java
+++ b/backend/src/main/java/com/mindtrack/appointment/controller/PatientAppointmentController.java
@@ -1,0 +1,45 @@
+package com.mindtrack.appointment.controller;
+
+import com.mindtrack.appointment.dto.AppointmentResponse;
+import com.mindtrack.appointment.service.AppointmentService;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Patient appointment access and cancellation API.
+ */
+@RestController
+@RequestMapping("/api/patient")
+public class PatientAppointmentController {
+
+    private final AppointmentService appointmentService;
+
+    public PatientAppointmentController(AppointmentService appointmentService) {
+        this.appointmentService = appointmentService;
+    }
+
+    /**
+     * Lists all appointments for the authenticated patient.
+     */
+    @GetMapping("/appointments")
+    public ResponseEntity<List<AppointmentResponse>> listAppointments(Authentication authentication) {
+        Long patientId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(appointmentService.listPatientAppointments(patientId));
+    }
+
+    /**
+     * Cancels one of the authenticated patient's appointments.
+     */
+    @PatchMapping("/appointments/{appointmentId}/cancel")
+    public ResponseEntity<AppointmentResponse> cancelAppointment(@PathVariable Long appointmentId,
+                                                                 Authentication authentication) {
+        Long patientId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(appointmentService.cancelAppointmentAsPatient(patientId, appointmentId));
+    }
+}

--- a/backend/src/main/java/com/mindtrack/appointment/dto/AppointmentResponse.java
+++ b/backend/src/main/java/com/mindtrack/appointment/dto/AppointmentResponse.java
@@ -4,12 +4,14 @@ import com.mindtrack.appointment.model.AppointmentStatus;
 import java.time.LocalDateTime;
 
 /**
- * Response payload for therapist appointments.
+ * Response payload for appointment views.
  */
 public class AppointmentResponse {
 
     private Long id;
     private Long therapistId;
+    private String therapistName;
+    private String therapistEmail;
     private Long patientId;
     private String patientName;
     private String patientEmail;
@@ -39,6 +41,22 @@ public class AppointmentResponse {
 
     public void setTherapistId(Long therapistId) {
         this.therapistId = therapistId;
+    }
+
+    public String getTherapistName() {
+        return therapistName;
+    }
+
+    public void setTherapistName(String therapistName) {
+        this.therapistName = therapistName;
+    }
+
+    public String getTherapistEmail() {
+        return therapistEmail;
+    }
+
+    public void setTherapistEmail(String therapistEmail) {
+        this.therapistEmail = therapistEmail;
     }
 
     public Long getPatientId() {

--- a/backend/src/main/java/com/mindtrack/appointment/repository/AppointmentRepository.java
+++ b/backend/src/main/java/com/mindtrack/appointment/repository/AppointmentRepository.java
@@ -14,6 +14,8 @@ public interface AppointmentRepository extends JpaRepository<Appointment, Long> 
 
     List<Appointment> findByTherapistIdOrderByStartAtAsc(Long therapistId);
 
+    List<Appointment> findByPatientIdOrderByStartAtAsc(Long patientId);
+
     List<Appointment> findByTherapistIdAndStatusInAndStartAtLessThanAndEndAtGreaterThan(
             Long therapistId,
             Collection<AppointmentStatus> status,

--- a/backend/src/main/java/com/mindtrack/appointment/service/AppointmentMapper.java
+++ b/backend/src/main/java/com/mindtrack/appointment/service/AppointmentMapper.java
@@ -12,10 +12,12 @@ import org.springframework.stereotype.Component;
 @Component
 public class AppointmentMapper {
 
-    public AppointmentResponse toResponse(Appointment appointment, User patient) {
+    public AppointmentResponse toResponse(Appointment appointment, User therapist, User patient) {
         AppointmentResponse response = new AppointmentResponse();
         response.setId(appointment.getId());
         response.setTherapistId(appointment.getTherapistId());
+        response.setTherapistName(therapist.getName());
+        response.setTherapistEmail(therapist.getEmail());
         response.setPatientId(appointment.getPatientId());
         response.setPatientName(patient.getName());
         response.setPatientEmail(patient.getEmail());

--- a/backend/src/main/java/com/mindtrack/appointment/service/AppointmentNotificationService.java
+++ b/backend/src/main/java/com/mindtrack/appointment/service/AppointmentNotificationService.java
@@ -67,6 +67,16 @@ public class AppointmentNotificationService {
         }
     }
 
+    /**
+     * Notifies both participants when an appointment is cancelled.
+     */
+    public void notifyParticipantsAboutCancellation(Appointment appointment, User therapist,
+                                                    User patient, User cancelledBy) {
+        String message = buildCancellationMessage(appointment, therapist, patient, cancelledBy);
+        sendImportantNotification(therapist, message);
+        sendImportantNotification(patient, message);
+    }
+
     private NotificationPreferences resolvePreferences(@Nullable UserProfile profile) {
         if (profile == null || !StringUtils.hasText(profile.getNotificationPrefs())) {
             return new NotificationPreferences(true, false);
@@ -121,35 +131,55 @@ public class AppointmentNotificationService {
     }
 
     private void sendEmail(User patient, User therapist, String message) {
+        sendEmail(patient, therapist, message, "New MindTrack appointment");
+    }
+
+    private void sendEmail(User recipient, User actor, String message, String subject) {
         if (mailSender == null) {
             LOG.warn("Skipping appointment email notification for patientId={} because mail is not configured",
-                    patient.getId());
+                    recipient.getId());
             return;
         }
-        if (!StringUtils.hasText(patient.getEmail())) {
+        if (!StringUtils.hasText(recipient.getEmail())) {
             LOG.warn("Skipping appointment email notification for patientId={} because no email exists",
-                    patient.getId());
+                    recipient.getId());
             return;
         }
 
         SimpleMailMessage mailMessage = new SimpleMailMessage();
-        mailMessage.setTo(patient.getEmail());
-        mailMessage.setSubject("New MindTrack appointment with " + displayName(therapist));
+        mailMessage.setTo(recipient.getEmail());
+        mailMessage.setSubject(subject + " with " + displayName(actor));
         mailMessage.setText(message);
 
         try {
             mailSender.send(mailMessage);
-            LOG.info("Sent appointment email notification to patientId={}", patient.getId());
+            LOG.info("Sent appointment email notification to patientId={}", recipient.getId());
         } catch (MailException ex) {
             LOG.warn("Failed to send appointment email notification to patientId={}: {}",
-                    patient.getId(), ex.getMessage());
+                    recipient.getId(), ex.getMessage());
         }
+    }
+
+    private void sendImportantNotification(User recipient, String message) {
+        UserProfile profile = userProfileRepository.findByUserId(recipient.getId()).orElse(null);
+        sendPushNotification(profile, recipient.getId(), message);
+        sendEmail(recipient, recipient, message, "MindTrack appointment update");
     }
 
     private String buildMessage(Appointment appointment, User therapist) {
         return "Your therapist " + displayName(therapist) + " booked a new appointment for "
                 + appointment.getStartAt().format(DATE_TIME_FORMATTER) + ".\n"
                 + "Ends at " + appointment.getEndAt().format(DateTimeFormatter.ofPattern("HH:mm")) + ".\n"
+                + "Reason: " + defaultText(appointment.getReason(), "No reason provided") + ".";
+    }
+
+    private String buildCancellationMessage(Appointment appointment, User therapist,
+                                            User patient, User cancelledBy) {
+        return "Appointment cancelled by " + displayName(cancelledBy) + ".\n"
+                + "Session: " + appointment.getStartAt().format(DATE_TIME_FORMATTER) + " - "
+                + appointment.getEndAt().format(DateTimeFormatter.ofPattern("HH:mm")) + ".\n"
+                + "Therapist: " + displayName(therapist) + ".\n"
+                + "Patient: " + displayName(patient) + ".\n"
                 + "Reason: " + defaultText(appointment.getReason(), "No reason provided") + ".";
     }
 

--- a/backend/src/main/java/com/mindtrack/appointment/service/AppointmentService.java
+++ b/backend/src/main/java/com/mindtrack/appointment/service/AppointmentService.java
@@ -48,9 +48,24 @@ public class AppointmentService {
     public List<AppointmentResponse> listAppointments(Long therapistId) {
         List<Appointment> appointments = appointmentRepository
                 .findByTherapistIdOrderByStartAtAsc(therapistId);
+        User therapist = loadUser(therapistId, "Therapist not found: ");
         return appointments.stream()
                 .map(appointment -> appointmentMapper.toResponse(
-                        appointment, loadPatient(appointment.getPatientId())))
+                        appointment, therapist, loadPatient(appointment.getPatientId())))
+                .toList();
+    }
+
+    /**
+     * Lists all appointments for the patient, ordered chronologically.
+     */
+    public List<AppointmentResponse> listPatientAppointments(Long patientId) {
+        List<Appointment> appointments = appointmentRepository.findByPatientIdOrderByStartAtAsc(patientId);
+        User patient = loadPatient(patientId);
+        return appointments.stream()
+                .map(appointment -> appointmentMapper.toResponse(
+                        appointment,
+                        loadUser(appointment.getTherapistId(), "Therapist not found: "),
+                        patient))
                 .toList();
     }
 
@@ -79,7 +94,46 @@ public class AppointmentService {
                 saved,
                 loadUser(therapistId, "Therapist not found: "),
                 patient);
-        return appointmentMapper.toResponse(saved, patient);
+        return appointmentMapper.toResponse(
+                saved,
+                loadUser(therapistId, "Therapist not found: "),
+                patient);
+    }
+
+    /**
+     * Cancels an appointment on behalf of the therapist.
+     */
+    @Transactional
+    public AppointmentResponse cancelAppointmentAsTherapist(Long therapistId, Long appointmentId) {
+        Appointment appointment = loadAppointment(appointmentId);
+        if (!therapistId.equals(appointment.getTherapistId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Appointment does not belong to therapist");
+        }
+        return cancelAppointment(appointment, loadUser(therapistId, "Therapist not found: "));
+    }
+
+    /**
+     * Cancels an appointment on behalf of the patient.
+     */
+    @Transactional
+    public AppointmentResponse cancelAppointmentAsPatient(Long patientId, Long appointmentId) {
+        Appointment appointment = loadAppointment(appointmentId);
+        if (!patientId.equals(appointment.getPatientId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Appointment does not belong to patient");
+        }
+        return cancelAppointment(appointment, loadPatient(patientId));
+    }
+
+    private AppointmentResponse cancelAppointment(Appointment appointment, User cancelledBy) {
+        validateCancellable(appointment);
+        appointment.setStatus(AppointmentStatus.CANCELLED);
+        Appointment saved = appointmentRepository.save(appointment);
+
+        User therapist = loadUser(saved.getTherapistId(), "Therapist not found: ");
+        User patient = loadPatient(saved.getPatientId());
+        appointmentNotificationService.notifyParticipantsAboutCancellation(
+                saved, therapist, patient, cancelledBy);
+        return appointmentMapper.toResponse(saved, therapist, patient);
     }
 
     private void validateRelationship(Long therapistId, Long patientId) {
@@ -121,6 +175,23 @@ public class AppointmentService {
 
     private User loadPatient(Long patientId) {
         return loadUser(patientId, PATIENT_NOT_FOUND_PREFIX);
+    }
+
+    private Appointment loadAppointment(Long appointmentId) {
+        return appointmentRepository.findById(appointmentId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "Appointment not found: " + appointmentId));
+    }
+
+    private void validateCancellable(Appointment appointment) {
+        if (appointment.getStatus() == AppointmentStatus.CANCELLED) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Appointment is already cancelled");
+        }
+        if (appointment.getStatus() != AppointmentStatus.SCHEDULED) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "Only scheduled appointments can be cancelled");
+        }
     }
 
     private User loadUser(Long userId, String notFoundPrefix) {

--- a/backend/src/test/java/com/mindtrack/appointment/controller/AppointmentControllerTest.java
+++ b/backend/src/test/java/com/mindtrack/appointment/controller/AppointmentControllerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -83,5 +84,18 @@ class AppointmentControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value(5))
                 .andExpect(jsonPath("$.status").value("SCHEDULED"));
+    }
+
+    @Test
+    void shouldCancelAppointment() throws Exception {
+        AppointmentResponse response = new AppointmentResponse();
+        response.setId(5L);
+        response.setStatus(AppointmentStatus.CANCELLED);
+        when(appointmentService.cancelAppointmentAsTherapist(3L, 5L)).thenReturn(response);
+
+        mockMvc.perform(patch("/api/therapist/appointments/5/cancel")
+                        .with(authentication(therapistAuth())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("CANCELLED"));
     }
 }

--- a/backend/src/test/java/com/mindtrack/appointment/controller/PatientAppointmentControllerTest.java
+++ b/backend/src/test/java/com/mindtrack/appointment/controller/PatientAppointmentControllerTest.java
@@ -1,0 +1,68 @@
+package com.mindtrack.appointment.controller;
+
+import com.mindtrack.appointment.dto.AppointmentResponse;
+import com.mindtrack.appointment.model.AppointmentStatus;
+import com.mindtrack.appointment.service.AppointmentService;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("local")
+class PatientAppointmentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AppointmentService appointmentService;
+
+    private static UsernamePasswordAuthenticationToken patientAuth() {
+        return new UsernamePasswordAuthenticationToken(
+                10L, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+    }
+
+    @Test
+    void shouldListPatientAppointments() throws Exception {
+        AppointmentResponse response = new AppointmentResponse();
+        response.setId(1L);
+        response.setTherapistName("Dr. Lane");
+        response.setStatus(AppointmentStatus.SCHEDULED);
+        when(appointmentService.listPatientAppointments(10L)).thenReturn(List.of(response));
+
+        mockMvc.perform(get("/api/patient/appointments")
+                        .with(authentication(patientAuth())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].therapistName").value("Dr. Lane"));
+    }
+
+    @Test
+    void shouldCancelPatientAppointment() throws Exception {
+        AppointmentResponse response = new AppointmentResponse();
+        response.setId(1L);
+        response.setStatus(AppointmentStatus.CANCELLED);
+        when(appointmentService.cancelAppointmentAsPatient(10L, 1L)).thenReturn(response);
+
+        mockMvc.perform(patch("/api/patient/appointments/1/cancel")
+                        .with(authentication(patientAuth())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("CANCELLED"));
+    }
+}

--- a/backend/src/test/java/com/mindtrack/appointment/service/AppointmentNotificationServiceTest.java
+++ b/backend/src/test/java/com/mindtrack/appointment/service/AppointmentNotificationServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -96,6 +97,24 @@ class AppointmentNotificationServiceTest {
                 org.mockito.ArgumentMatchers.contains("Weekly check-in"));
         verify(telegramService, never()).sendMessage(org.mockito.ArgumentMatchers.anyString(),
                 org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void shouldNotifyBothParticipantsWhenAppointmentIsCancelled() {
+        when(userProfileRepository.findByUserId(3L)).thenReturn(Optional.of(createProfile(
+                3L, null, "999", null)));
+        when(userProfileRepository.findByUserId(10L)).thenReturn(Optional.of(createProfile(
+                10L, null, null, null)));
+
+        appointmentNotificationService.notifyParticipantsAboutCancellation(
+                createAppointment(),
+                createUser(3L, "Dr. Lane", "therapist@test.com"),
+                createUser(10L, "Patient One", "patient@test.com"),
+                createUser(10L, "Patient One", "patient@test.com"));
+
+        verify(telegramService).sendMessage(org.mockito.ArgumentMatchers.eq("999"),
+                org.mockito.ArgumentMatchers.contains("Appointment cancelled by Patient One"));
+        verify(mailSender, times(2)).send(org.mockito.ArgumentMatchers.any(SimpleMailMessage.class));
     }
 
     private Appointment createAppointment() {

--- a/backend/src/test/java/com/mindtrack/appointment/service/AppointmentServiceTest.java
+++ b/backend/src/test/java/com/mindtrack/appointment/service/AppointmentServiceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -58,6 +59,7 @@ class AppointmentServiceTest {
 
         when(appointmentRepository.findByTherapistIdOrderByStartAtAsc(3L))
                 .thenReturn(List.of(first, second));
+        when(userRepository.findById(3L)).thenReturn(Optional.of(createUser(3L, "Therapist A")));
         when(userRepository.findById(10L)).thenReturn(Optional.of(createUser(10L, "Patient A")));
         when(userRepository.findById(11L)).thenReturn(Optional.of(createUser(11L, "Patient B")));
 
@@ -65,6 +67,7 @@ class AppointmentServiceTest {
 
         assertEquals(2, result.size());
         assertEquals("Patient A", result.get(0).getPatientName());
+        assertEquals("Therapist A", result.get(0).getTherapistName());
         assertEquals(50L, result.get(0).getDurationMinutes());
     }
 
@@ -139,6 +142,37 @@ class AppointmentServiceTest {
 
         assertThrows(IllegalArgumentException.class,
                 () -> appointmentService.bookAppointment(3L, 10L, request));
+    }
+
+    @Test
+    void shouldCancelAppointmentForTherapist() {
+        Appointment appointment = createAppointment(5L, 3L, 10L,
+                LocalDateTime.of(2025, 1, 20, 10, 0),
+                LocalDateTime.of(2025, 1, 20, 10, 50));
+        when(appointmentRepository.findById(5L)).thenReturn(Optional.of(appointment));
+        when(appointmentRepository.save(any(Appointment.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(userRepository.findById(3L)).thenReturn(Optional.of(createUser(3L, "Therapist A")));
+        when(userRepository.findById(10L)).thenReturn(Optional.of(createUser(10L, "Patient A")));
+
+        AppointmentResponse result = appointmentService.cancelAppointmentAsTherapist(3L, 5L);
+
+        assertEquals(AppointmentStatus.CANCELLED, result.getStatus());
+        verify(appointmentNotificationService).notifyParticipantsAboutCancellation(any(), any(), any(), any());
+    }
+
+    @Test
+    void shouldRejectDuplicateCancellation() {
+        Appointment appointment = createAppointment(5L, 3L, 10L,
+                LocalDateTime.of(2025, 1, 20, 10, 0),
+                LocalDateTime.of(2025, 1, 20, 10, 50));
+        appointment.setStatus(AppointmentStatus.CANCELLED);
+        when(appointmentRepository.findById(5L)).thenReturn(Optional.of(appointment));
+        when(userRepository.findById(3L)).thenReturn(Optional.of(createUser(3L, "Therapist A")));
+
+        ResponseStatusException error = assertThrows(ResponseStatusException.class,
+                () -> appointmentService.cancelAppointmentAsTherapist(3L, 5L));
+
+        assertEquals(HttpStatus.CONFLICT, error.getStatusCode());
     }
 
     private Appointment createAppointment(Long id, Long therapistId, Long patientId,

--- a/frontend/src/components/layout/AppNavbar.vue
+++ b/frontend/src/components/layout/AppNavbar.vue
@@ -21,6 +21,7 @@ function handleLogout() {
 
       <div class="navbar-links">
         <router-link to="/dashboard" class="nav-link">Dashboard</router-link>
+        <router-link to="/appointments" class="nav-link">Appointments</router-link>
         <router-link to="/journal" class="nav-link">Journal</router-link>
         <router-link to="/activities" class="nav-link">Activities</router-link>
         <router-link to="/goals" class="nav-link">Goals</router-link>

--- a/frontend/src/components/layout/__tests__/AppNavbar.test.ts
+++ b/frontend/src/components/layout/__tests__/AppNavbar.test.ts
@@ -24,6 +24,7 @@ const router = createRouter({
   history: createMemoryHistory(),
   routes: [
     { path: '/dashboard', component: { template: '<div>Dashboard</div>' } },
+    { path: '/appointments', component: { template: '<div>Appointments</div>' } },
     { path: '/journal', component: { template: '<div>Journal</div>' } },
     { path: '/activities', component: { template: '<div>Activities</div>' } },
     { path: '/goals', component: { template: '<div>Goals</div>' } },
@@ -66,6 +67,7 @@ describe('AppNavbar', () => {
     const links = wrapper.findAll('.nav-link')
     const linkTexts = links.map((l) => l.text())
     expect(linkTexts).toContain('Dashboard')
+    expect(linkTexts).toContain('Appointments')
     expect(linkTexts).toContain('Journal')
     expect(linkTexts).toContain('Activities')
     expect(linkTexts).toContain('Goals')

--- a/frontend/src/router/__tests__/index.test.ts
+++ b/frontend/src/router/__tests__/index.test.ts
@@ -28,6 +28,7 @@ const stub = { template: '<div />' }
 vi.mock('@/views/LandingView.vue', () => ({ default: stub }))
 vi.mock('@/views/LoginView.vue', () => ({ default: stub }))
 vi.mock('@/views/DashboardView.vue', () => ({ default: stub }))
+vi.mock('@/views/PatientAppointmentsView.vue', () => ({ default: stub }))
 vi.mock('@/views/InterviewsView.vue', () => ({ default: stub }))
 vi.mock('@/views/InterviewFormView.vue', () => ({ default: stub }))
 vi.mock('@/views/InterviewDetailView.vue', () => ({ default: stub }))
@@ -98,6 +99,13 @@ describe('Router', () => {
   it('has dashboard route with requiresAuth', () => {
     const route = router.getRoutes().find((r) => r.path === '/dashboard')
     expect(route).toBeDefined()
+    expect(route?.meta.requiresAuth).toBe(true)
+  })
+
+  it('has patient appointments route with requiresAuth', () => {
+    const route = router.getRoutes().find((r) => r.path === '/appointments')
+    expect(route).toBeDefined()
+    expect(route?.name).toBe('appointments')
     expect(route?.meta.requiresAuth).toBe(true)
   })
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -55,6 +55,11 @@ const router = createRouter({
     publicRoute('/', 'landing', () => import('@/views/LandingView.vue')),
     publicRoute('/login', 'login', () => import('@/views/LoginView.vue')),
     protectedRoute('/dashboard', 'dashboard', () => import('@/views/DashboardView.vue')),
+    protectedRoute(
+      '/appointments',
+      'appointments',
+      () => import('@/views/PatientAppointmentsView.vue'),
+    ),
     protectedRoute('/interviews', 'interviews', () => import('@/views/InterviewsView.vue')),
     protectedRoute(
       '/interviews/new',

--- a/frontend/src/stores/__tests__/appointments.test.ts
+++ b/frontend/src/stores/__tests__/appointments.test.ts
@@ -7,6 +7,8 @@ const mockAppointments: AppointmentSummary[] = [
   {
     id: 1,
     therapistId: 3,
+    therapistName: 'Dr. Lane',
+    therapistEmail: 'therapist@test.com',
     patientId: 10,
     patientName: 'Patient One',
     patientEmail: 'patient1@test.com',
@@ -35,6 +37,7 @@ describe('useAppointmentStore', () => {
   let api: {
     get: ReturnType<typeof vi.fn>
     post: ReturnType<typeof vi.fn>
+    patch: ReturnType<typeof vi.fn>
   }
 
   beforeEach(async () => {
@@ -80,5 +83,22 @@ describe('useAppointmentStore', () => {
     })
     expect(store.appointments[0].id).toBe(2)
     expect(store.notice).toBe('Appointment booked')
+  })
+
+  it('cancels an appointment for the patient', async () => {
+    api.patch.mockResolvedValueOnce({
+      data: {
+        ...mockAppointments[0],
+        status: 'CANCELLED',
+      },
+    })
+    const store = useAppointmentStore()
+    store.appointments = mockAppointments
+
+    await store.cancelAppointmentForPatient(1)
+
+    expect(api.patch).toHaveBeenCalledWith('/patient/appointments/1/cancel')
+    expect(store.appointments[0].status).toBe('CANCELLED')
+    expect(store.notice).toBe('Appointment cancelled')
   })
 })

--- a/frontend/src/stores/appointments.ts
+++ b/frontend/src/stores/appointments.ts
@@ -5,6 +5,8 @@ import api from '@/services/api'
 export interface AppointmentSummary {
   id: number
   therapistId: number
+  therapistName: string | null
+  therapistEmail: string | null
   patientId: number
   patientName: string
   patientEmail: string
@@ -29,15 +31,22 @@ export const useAppointmentStore = defineStore('appointments', () => {
   const appointments = ref<AppointmentSummary[]>([])
   const loading = ref(false)
   const booking = ref(false)
+  const cancelling = ref<number | null>(null)
   const error = ref<string | null>(null)
   const notice = ref<string | null>(null)
+
+  function sortAppointments(nextAppointments: AppointmentSummary[]) {
+    appointments.value = [...nextAppointments].sort((left, right) =>
+      left.startAt.localeCompare(right.startAt),
+    )
+  }
 
   async function fetchAppointments() {
     loading.value = true
     error.value = null
     try {
       const response = await api.get('/therapist/appointments')
-      appointments.value = response.data
+      sortAppointments(response.data)
     } catch (err) {
       error.value = 'Failed to load appointments'
       throw err
@@ -52,9 +61,7 @@ export const useAppointmentStore = defineStore('appointments', () => {
     notice.value = null
     try {
       const response = await api.post(`/therapist/patients/${patientId}/appointments`, request)
-      appointments.value = [...appointments.value, response.data].sort((left, right) =>
-        left.startAt.localeCompare(right.startAt),
-      )
+      sortAppointments([...appointments.value, response.data])
       notice.value = 'Appointment booked'
       return response.data
     } catch (err) {
@@ -62,6 +69,62 @@ export const useAppointmentStore = defineStore('appointments', () => {
       throw err
     } finally {
       booking.value = false
+    }
+  }
+
+  async function fetchPatientAppointments() {
+    loading.value = true
+    error.value = null
+    try {
+      const response = await api.get('/patient/appointments')
+      sortAppointments(response.data)
+    } catch (err) {
+      error.value = 'Failed to load appointments'
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function cancelAppointmentForTherapist(appointmentId: number) {
+    cancelling.value = appointmentId
+    error.value = null
+    notice.value = null
+    try {
+      const response = await api.patch(`/therapist/appointments/${appointmentId}/cancel`)
+      sortAppointments(
+        appointments.value.map((appointment) =>
+          appointment.id === appointmentId ? response.data : appointment,
+        ),
+      )
+      notice.value = 'Appointment cancelled'
+      return response.data
+    } catch (err) {
+      error.value = 'Failed to cancel appointment'
+      throw err
+    } finally {
+      cancelling.value = null
+    }
+  }
+
+  async function cancelAppointmentForPatient(appointmentId: number) {
+    cancelling.value = appointmentId
+    error.value = null
+    notice.value = null
+    try {
+      const response = await api.patch(`/patient/appointments/${appointmentId}/cancel`)
+      sortAppointments(
+        appointments.value.map((appointment) =>
+          appointment.id === appointmentId ? response.data : appointment,
+        ),
+      )
+      notice.value = 'Appointment cancelled'
+      return response.data
+    } catch (err) {
+      error.value = 'Failed to cancel appointment'
+      throw err
+    } finally {
+      cancelling.value = null
     }
   }
 
@@ -77,10 +140,14 @@ export const useAppointmentStore = defineStore('appointments', () => {
     appointments,
     loading,
     booking,
+    cancelling,
     error,
     notice,
     fetchAppointments,
+    fetchPatientAppointments,
     bookAppointment,
+    cancelAppointmentForTherapist,
+    cancelAppointmentForPatient,
     clearNotice,
     clearError,
   }

--- a/frontend/src/views/PatientAppointmentsView.vue
+++ b/frontend/src/views/PatientAppointmentsView.vue
@@ -1,0 +1,188 @@
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { useAppointmentStore } from '@/stores/appointments'
+
+const appointmentStore = useAppointmentStore()
+
+onMounted(async () => {
+  try {
+    await appointmentStore.fetchPatientAppointments()
+  } catch {
+    // Store-level error handles the failure state.
+  }
+})
+
+const upcomingAppointments = computed(() => {
+  const now = new Date()
+  return appointmentStore.appointments.filter((appointment) => new Date(appointment.startAt) >= now)
+})
+
+const pastAppointments = computed(() => {
+  const now = new Date()
+  return appointmentStore.appointments.filter((appointment) => new Date(appointment.startAt) < now)
+})
+
+function formatDateTime(value: string): string {
+  return new Intl.DateTimeFormat('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(new Date(value))
+}
+
+function formatStatus(status: string): string {
+  return status.replaceAll('_', ' ').toLowerCase()
+}
+
+async function cancelAppointment(appointmentId: number) {
+  try {
+    await appointmentStore.cancelAppointmentForPatient(appointmentId)
+  } catch {
+    // Store-level error handles the failure state.
+  }
+}
+</script>
+
+<template>
+  <div class="patient-appointments-view">
+    <header class="page-header">
+      <div>
+        <h1>My Appointments</h1>
+        <p class="subtitle">Track upcoming sessions and cancel if plans change.</p>
+      </div>
+    </header>
+
+    <div v-if="appointmentStore.error" class="notice notice-error">
+      <p>{{ appointmentStore.error }}</p>
+      <button class="btn btn-secondary" @click="appointmentStore.clearError()">Dismiss</button>
+    </div>
+
+    <div v-if="appointmentStore.notice" class="notice notice-success">
+      <p>{{ appointmentStore.notice }}</p>
+      <button class="btn btn-secondary" @click="appointmentStore.clearNotice()">Dismiss</button>
+    </div>
+
+    <div v-if="appointmentStore.loading" class="empty-state">Loading appointments...</div>
+
+    <div v-else class="appointments-layout">
+      <section class="panel">
+        <div class="panel-header">
+          <h2>Upcoming</h2>
+        </div>
+        <div v-if="upcomingAppointments.length === 0" class="empty-state">
+          No upcoming appointments scheduled.
+        </div>
+        <div v-else class="appointments-list">
+          <article
+            v-for="appointment in upcomingAppointments"
+            :key="appointment.id"
+            class="appointment-card"
+          >
+            <div class="status-row">
+              <strong>{{ appointment.therapistName || 'Therapist' }}</strong>
+              <span class="status-pill">{{ formatStatus(appointment.status) }}</span>
+            </div>
+            <p>{{ formatDateTime(appointment.startAt) }}</p>
+            <p>{{ appointment.reason || 'No reason supplied' }}</p>
+            <button
+              v-if="appointment.status === 'SCHEDULED'"
+              class="btn btn-secondary"
+              :disabled="appointmentStore.cancelling === appointment.id"
+              @click="cancelAppointment(appointment.id)"
+            >
+              {{
+                appointmentStore.cancelling === appointment.id
+                  ? 'Cancelling...'
+                  : 'Cancel appointment'
+              }}
+            </button>
+          </article>
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="panel-header">
+          <h2>Past</h2>
+        </div>
+        <div v-if="pastAppointments.length === 0" class="empty-state">
+          No past appointments yet.
+        </div>
+        <div v-else class="appointments-list">
+          <article
+            v-for="appointment in pastAppointments"
+            :key="appointment.id"
+            class="appointment-card appointment-card--muted"
+          >
+            <div class="status-row">
+              <strong>{{ appointment.therapistName || 'Therapist' }}</strong>
+              <span class="status-pill">{{ formatStatus(appointment.status) }}</span>
+            </div>
+            <p>{{ formatDateTime(appointment.startAt) }}</p>
+            <p>{{ appointment.reason || 'No reason supplied' }}</p>
+          </article>
+        </div>
+      </section>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.appointments-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--space-6);
+}
+
+.panel {
+  background: var(--color-white);
+  border: 1px solid var(--color-gray-200);
+  border-radius: var(--border-radius-lg);
+  padding: var(--space-6);
+}
+
+.panel-header {
+  margin-bottom: var(--space-4);
+}
+
+.appointments-list {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.appointment-card {
+  border: 1px solid var(--color-gray-200);
+  border-radius: var(--border-radius);
+  padding: var(--space-4);
+  background: #fafaf7;
+}
+
+.appointment-card--muted {
+  opacity: 0.8;
+}
+
+.status-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.status-pill {
+  border-radius: 999px;
+  background: var(--color-gray-100);
+  color: var(--color-gray-700);
+  padding: 0.15rem 0.55rem;
+  font-size: var(--font-size-xs);
+  text-transform: capitalize;
+}
+
+.notice {
+  margin-bottom: var(--space-4);
+}
+
+.empty-state {
+  color: var(--color-gray-500);
+}
+</style>

--- a/frontend/src/views/TherapistCalendarView.vue
+++ b/frontend/src/views/TherapistCalendarView.vue
@@ -147,6 +147,14 @@ async function submitBooking() {
     // Store-level error handles the failure state.
   }
 }
+
+async function cancelAppointment(appointmentId: number) {
+  try {
+    await appointmentStore.cancelAppointmentForTherapist(appointmentId)
+  } catch {
+    // Store-level error handles the failure state.
+  }
+}
 </script>
 
 <template>
@@ -300,6 +308,18 @@ async function submitBooking() {
                   </div>
                   <h4>{{ appointment.patientName }}</h4>
                   <p class="appointment-reason">{{ appointment.reason || 'No reason supplied' }}</p>
+                  <button
+                    v-if="appointment.status === 'SCHEDULED'"
+                    class="btn btn-secondary btn-inline"
+                    :disabled="appointmentStore.cancelling === appointment.id"
+                    @click="cancelAppointment(appointment.id)"
+                  >
+                    {{
+                      appointmentStore.cancelling === appointment.id
+                        ? 'Cancelling...'
+                        : 'Cancel appointment'
+                    }}
+                  </button>
                 </div>
               </article>
             </div>
@@ -328,6 +348,18 @@ async function submitBooking() {
                   </div>
                   <h4>{{ appointment.patientName }}</h4>
                   <p class="appointment-reason">{{ appointment.reason || 'No reason supplied' }}</p>
+                  <button
+                    v-if="appointment.status === 'SCHEDULED'"
+                    class="btn btn-secondary btn-inline"
+                    :disabled="appointmentStore.cancelling === appointment.id"
+                    @click="cancelAppointment(appointment.id)"
+                  >
+                    {{
+                      appointmentStore.cancelling === appointment.id
+                        ? 'Cancelling...'
+                        : 'Cancel appointment'
+                    }}
+                  </button>
                 </div>
               </article>
             </div>
@@ -533,6 +565,11 @@ async function submitBooking() {
 
 .btn-full {
   width: 100%;
+}
+
+.btn-inline {
+  justify-self: start;
+  margin-top: var(--space-2);
 }
 
 .agenda-columns {

--- a/frontend/src/views/__tests__/PatientAppointmentsView.test.ts
+++ b/frontend/src/views/__tests__/PatientAppointmentsView.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import PatientAppointmentsView from '../PatientAppointmentsView.vue'
+
+const appointments = [
+  {
+    id: 1,
+    therapistId: 3,
+    therapistName: 'Dr. Lane',
+    therapistEmail: 'therapist@test.com',
+    patientId: 10,
+    patientName: 'Patient One',
+    patientEmail: 'patient@test.com',
+    startAt: '2026-04-20T10:00:00',
+    endAt: '2026-04-20T10:50:00',
+    status: 'SCHEDULED',
+    reason: 'Follow-up',
+    notes: null,
+    durationMinutes: 50,
+    createdAt: '2026-04-01T10:00:00',
+    updatedAt: '2026-04-01T10:00:00',
+  },
+]
+
+const mockGet = vi.fn()
+const mockPatch = vi.fn()
+
+vi.mock('@/services/api', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: (...args: unknown[]) => mockPatch(...args),
+    delete: vi.fn(),
+  },
+}))
+
+describe('PatientAppointmentsView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockGet.mockReset()
+    mockPatch.mockReset()
+  })
+
+  it('renders the patient appointment list', async () => {
+    mockGet.mockResolvedValueOnce({ data: appointments })
+
+    const wrapper = mount(PatientAppointmentsView)
+    await flushPromises()
+
+    expect(wrapper.find('h1').text()).toContain('My Appointments')
+    expect(wrapper.text()).toContain('Dr. Lane')
+    expect(wrapper.text()).toContain('Follow-up')
+  })
+
+  it('cancels a patient appointment', async () => {
+    mockGet.mockResolvedValueOnce({ data: appointments })
+    mockPatch.mockResolvedValueOnce({
+      data: {
+        ...appointments[0],
+        status: 'CANCELLED',
+      },
+    })
+
+    const wrapper = mount(PatientAppointmentsView)
+    await flushPromises()
+
+    await wrapper.find('button.btn.btn-secondary').trigger('click')
+    await flushPromises()
+
+    expect(mockPatch).toHaveBeenCalledWith('/patient/appointments/1/cancel')
+    expect(wrapper.text()).toContain('Appointment cancelled')
+  })
+})

--- a/frontend/src/views/__tests__/TherapistCalendarView.test.ts
+++ b/frontend/src/views/__tests__/TherapistCalendarView.test.ts
@@ -50,13 +50,14 @@ const appointments = [
 
 const mockGet = vi.fn()
 const mockPost = vi.fn()
+const mockPatch = vi.fn()
 
 vi.mock('@/services/api', () => ({
   default: {
     get: (...args: unknown[]) => mockGet(...args),
     post: (...args: unknown[]) => mockPost(...args),
     put: vi.fn(),
-    patch: vi.fn(),
+    patch: (...args: unknown[]) => mockPatch(...args),
     delete: vi.fn(),
   },
 }))
@@ -66,6 +67,7 @@ describe('TherapistCalendarView', () => {
     setActivePinia(createPinia())
     mockGet.mockReset()
     mockPost.mockReset()
+    mockPatch.mockReset()
   })
 
   it('renders the appointment agenda', async () => {
@@ -113,5 +115,28 @@ describe('TherapistCalendarView', () => {
       notes: 'Bring worksheets',
     })
     expect(wrapper.text()).toContain('Appointment booked')
+  })
+
+  it('cancels a scheduled appointment', async () => {
+    mockGet.mockResolvedValueOnce({ data: patients })
+    mockGet.mockResolvedValueOnce({ data: appointments })
+    mockPatch.mockResolvedValueOnce({
+      data: {
+        ...appointments[0],
+        status: 'CANCELLED',
+      },
+    })
+
+    const wrapper = mount(TherapistCalendarView)
+    await flushPromises()
+
+    const cancelButton = wrapper
+      .findAll('button')
+      .find((button) => button.text().includes('Cancel appointment'))
+    await cancelButton!.trigger('click')
+    await flushPromises()
+
+    expect(mockPatch).toHaveBeenCalledWith('/therapist/appointments/1/cancel')
+    expect(wrapper.text()).toContain('Appointment cancelled')
   })
 })


### PR DESCRIPTION
## Summary
- add therapist and patient appointment cancellation endpoints
- notify both participants when a cancellation happens
- add patient appointments page and therapist calendar cancel controls

## Testing
- mvn -Dtest=AppointmentServiceTest,AppointmentNotificationServiceTest,AppointmentControllerTest,PatientAppointmentControllerTest test
- npm run test:unit -- --run src/stores/__tests__/appointments.test.ts src/views/__tests__/TherapistCalendarView.test.ts src/views/__tests__/PatientAppointmentsView.test.ts src/router/__tests__/index.test.ts src/components/layout/__tests__/AppNavbar.test.ts
- npm run build

Closes #324