### PR TITLE
fix(sonar): resolve current unresolved findings

### DIFF
--- a/backend/src/main/java/com/mindtrack/appointment/service/AppointmentService.java
+++ b/backend/src/main/java/com/mindtrack/appointment/service/AppointmentService.java
@@ -92,9 +92,13 @@ public class AppointmentService {
         LocalDateTime endAt = startAt.plusMinutes(request.getDurationMinutes());
         validateConflicts(therapistId, patientId, startAt, endAt);
 
-        Appointment appointment = buildAppointment(therapistId, patientId, startAt, endAt,
-                request.getDurationMinutes(), request.getReason(), request.getNotes(),
-                null, null, null);
+        Appointment appointment = buildAppointment(
+                therapistId,
+                patientId,
+                request,
+                startAt,
+                endAt,
+                RecurrenceContext.none());
 
         User patient = loadUser(patientId, PATIENT_NOT_FOUND_PREFIX);
         Appointment saved = appointmentRepository.save(appointment);
@@ -123,9 +127,13 @@ public class AppointmentService {
                 break;
             }
             LocalDateTime endAt = startAt.plusMinutes(request.getDurationMinutes());
-            occurrences.add(buildAppointment(therapistId, patientId, startAt, endAt,
-                    request.getDurationMinutes(), request.getReason(), request.getNotes(),
-                    RecurrenceType.WEEKLY.name(), seriesId, i));
+            occurrences.add(buildAppointment(
+                    therapistId,
+                    patientId,
+                    request,
+                    startAt,
+                    endAt,
+                    new RecurrenceContext(RecurrenceType.WEEKLY.name(), seriesId, i)));
         }
 
         if (occurrences.isEmpty()) {
@@ -196,22 +204,21 @@ public class AppointmentService {
     }
 
     private Appointment buildAppointment(Long therapistId, Long patientId,
+                                          AppointmentRequest request,
                                           LocalDateTime startAt, LocalDateTime endAt,
-                                          int durationMinutes, String reason, String notes,
-                                          String recurrenceRule, String seriesId,
-                                          Integer seriesIndex) {
+                                          RecurrenceContext recurrenceContext) {
         Appointment appointment = new Appointment();
         appointment.setTherapistId(therapistId);
         appointment.setPatientId(patientId);
         appointment.setStartAt(startAt);
         appointment.setEndAt(endAt);
-        appointment.setDurationMinutes(durationMinutes);
+        appointment.setDurationMinutes(request.getDurationMinutes());
         appointment.setStatus(AppointmentStatus.SCHEDULED);
-        appointment.setReason(reason);
-        appointment.setNotes(notes);
-        appointment.setRecurrenceRule(recurrenceRule);
-        appointment.setSeriesId(seriesId);
-        appointment.setSeriesIndex(seriesIndex);
+        appointment.setReason(request.getReason());
+        appointment.setNotes(request.getNotes());
+        appointment.setRecurrenceRule(recurrenceContext.recurrenceRule());
+        appointment.setSeriesId(recurrenceContext.seriesId());
+        appointment.setSeriesIndex(recurrenceContext.seriesIndex());
         return appointment;
     }
 
@@ -260,5 +267,13 @@ public class AppointmentService {
                 .filter(rel -> rel.getStatus() == TherapistPatientStatus.ACTIVE)
                 .map(TherapistPatient::getCalendarColor)
                 .orElse(null);
+    }
+
+    private record RecurrenceContext(String recurrenceRule, String seriesId,
+                                     Integer seriesIndex) {
+
+        private static RecurrenceContext none() {
+            return new RecurrenceContext(null, null, null);
+        }
     }
 }

--- a/backend/src/main/java/com/mindtrack/therapist/dto/CalendarColorRequest.java
+++ b/backend/src/main/java/com/mindtrack/therapist/dto/CalendarColorRequest.java
@@ -13,6 +13,7 @@ public class CalendarColorRequest {
     private String calendarColor;
 
     public CalendarColorRequest() {
+        // Default constructor for JSON deserialization.
     }
 
     public String getCalendarColor() {

--- a/frontend/src/components/AppointmentCancelModal.vue
+++ b/frontend/src/components/AppointmentCancelModal.vue
@@ -25,12 +25,12 @@ function handleCancel() {
 </script>
 
 <template>
-  <div
+  <dialog
     v-if="show"
     class="modal-backdrop"
-    role="dialog"
-    aria-modal="true"
+    open
     aria-labelledby="cancel-modal-title"
+    @cancel.prevent="handleCancel"
   >
     <div class="modal-panel">
       <h3 id="cancel-modal-title">Cancel appointment</h3>
@@ -59,23 +59,27 @@ function handleCancel() {
         </button>
       </div>
     </div>
-  </div>
+  </dialog>
 </template>
 
 <style scoped>
 .modal-backdrop {
-  position: fixed;
-  inset: 0;
   z-index: 100;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  width: min(420px, 92vw);
+  max-width: none;
+  margin: auto;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+}
+
+.modal-backdrop::backdrop {
   background: rgba(2, 6, 23, 0.7);
   backdrop-filter: blur(4px);
 }
 
 .modal-panel {
-  width: min(420px, 92vw);
   padding: var(--space-6);
   border-radius: 20px;
   background: #0f172a;
@@ -127,9 +131,9 @@ function handleCancel() {
 }
 
 .btn-danger {
-  color: #fecaca;
-  background: rgba(220, 38, 38, 0.2);
-  border: 1px solid rgba(220, 38, 38, 0.4);
+  color: #fff1f2;
+  background: rgba(153, 27, 27, 0.78);
+  border: 1px solid rgba(248, 113, 113, 0.62);
   padding: var(--space-2) var(--space-4);
   border-radius: 12px;
   cursor: pointer;
@@ -139,7 +143,7 @@ function handleCancel() {
 }
 
 .btn-danger:hover {
-  background: rgba(220, 38, 38, 0.32);
-  border-color: rgba(220, 38, 38, 0.6);
+  background: rgba(185, 28, 28, 0.9);
+  border-color: rgba(252, 165, 165, 0.78);
 }
 </style>

--- a/frontend/src/components/NotificationPanel.vue
+++ b/frontend/src/components/NotificationPanel.vue
@@ -39,20 +39,20 @@ async function handleClick(id: number, link: string | null) {
     </div>
 
     <ul v-else class="notification-panel__list">
-      <li
-        v-for="notification in notifications.notifications"
-        :key="notification.id"
-        :class="['notification-item', { 'notification-item--unread': !notification.read }]"
-        role="button"
-        tabindex="0"
-        @click="handleClick(notification.id, notification.link)"
-        @keydown.enter="handleClick(notification.id, notification.link)"
-      >
-        <div class="notification-item__title">{{ notification.title }}</div>
-        <div v-if="notification.body" class="notification-item__body">{{ notification.body }}</div>
-        <div class="notification-item__time">
-          {{ new Date(notification.createdAt).toLocaleString() }}
-        </div>
+      <li v-for="notification in notifications.notifications" :key="notification.id">
+        <button
+          type="button"
+          :class="['notification-item', { 'notification-item--unread': !notification.read }]"
+          @click="handleClick(notification.id, notification.link)"
+        >
+          <div class="notification-item__title">{{ notification.title }}</div>
+          <div v-if="notification.body" class="notification-item__body">
+            {{ notification.body }}
+          </div>
+          <div class="notification-item__time">
+            {{ new Date(notification.createdAt).toLocaleString() }}
+          </div>
+        </button>
       </li>
     </ul>
   </div>
@@ -109,15 +109,23 @@ async function handleClick(id: number, link: string | null) {
   padding: 0;
 }
 
-.notification-item {
-  padding: var(--space-3) var(--space-4);
+.notification-panel__list li {
   border-bottom: 1px solid var(--color-gray-100);
-  cursor: pointer;
-  transition: background-color var(--transition-fast);
 }
 
-.notification-item:last-child {
+.notification-panel__list li:last-child {
   border-bottom: none;
+}
+
+.notification-item {
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  border: none;
+  background: none;
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  transition: background-color var(--transition-fast);
 }
 
 .notification-item:hover {

--- a/frontend/src/components/__tests__/AppointmentCancelModal.test.ts
+++ b/frontend/src/components/__tests__/AppointmentCancelModal.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AppointmentCancelModal from '../AppointmentCancelModal.vue'
+
+describe('AppointmentCancelModal', () => {
+  it('renders an open dialog when visible', () => {
+    const wrapper = mount(AppointmentCancelModal, {
+      props: {
+        show: true,
+        isSeries: false,
+      },
+    })
+
+    const dialog = wrapper.find('dialog')
+
+    expect(dialog.exists()).toBe(true)
+    expect(dialog.attributes('open')).toBeDefined()
+    expect(dialog.attributes('aria-labelledby')).toBe('cancel-modal-title')
+  })
+
+  it('emits the selected scope on confirm', async () => {
+    const wrapper = mount(AppointmentCancelModal, {
+      props: {
+        show: true,
+        isSeries: true,
+      },
+    })
+
+    await wrapper.find('input[value="ALL_IN_SERIES"]').setValue()
+    await wrapper.find('.btn-danger').trigger('click')
+
+    expect(wrapper.emitted('confirm')).toEqual([['ALL_IN_SERIES']])
+  })
+})

--- a/frontend/src/components/__tests__/NotificationPanel.test.ts
+++ b/frontend/src/components/__tests__/NotificationPanel.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import NotificationPanel from '../NotificationPanel.vue'
+
+const mockGet = vi.fn()
+const mockPatch = vi.fn()
+const push = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push }),
+}))
+
+vi.mock('@/services/api', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    patch: (...args: unknown[]) => mockPatch(...args),
+  },
+}))
+
+describe('NotificationPanel', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockGet.mockReset()
+    mockPatch.mockReset()
+    push.mockReset()
+  })
+
+  it('renders interactive notifications as buttons', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        content: [
+          {
+            id: 1,
+            type: 'APPOINTMENT',
+            title: 'Upcoming appointment',
+            body: 'Tomorrow at 10:00',
+            read: false,
+            link: '/appointments',
+            createdAt: '2026-03-21T10:00:00Z',
+          },
+        ],
+      },
+    })
+    mockPatch.mockResolvedValueOnce({
+      data: {
+        id: 1,
+        type: 'APPOINTMENT',
+        title: 'Upcoming appointment',
+        body: 'Tomorrow at 10:00',
+        read: true,
+        link: '/appointments',
+        createdAt: '2026-03-21T10:00:00Z',
+      },
+    })
+
+    const wrapper = mount(NotificationPanel)
+    await flushPromises()
+
+    const notificationButton = wrapper.find('.notification-item')
+    expect(notificationButton.element.tagName).toBe('BUTTON')
+
+    await notificationButton.trigger('click')
+
+    expect(mockPatch).toHaveBeenCalledWith('/notifications/1/read')
+  })
+})

--- a/frontend/src/components/dashboard/VideoWidget.vue
+++ b/frontend/src/components/dashboard/VideoWidget.vue
@@ -14,7 +14,7 @@ function getSecureRandomIndex(length: number) {
   if (!cryptoApi?.getRandomValues) return 0
 
   const randomValue = new Uint32Array(1)
-  const maxUint32Exclusive = 0x1_0000_0000
+  const maxUint32Exclusive = 2 ** 32
   const unbiasedUpperBound = maxUint32Exclusive - (maxUint32Exclusive % length)
 
   do {

--- a/frontend/src/views/TherapistCalendarView.vue
+++ b/frontend/src/views/TherapistCalendarView.vue
@@ -811,23 +811,23 @@ async function submitBooking() {
 }
 
 .status-scheduled {
-  color: #fef3c7;
-  background: rgba(217, 119, 6, 0.16);
+  color: #fffbeb;
+  background: rgba(146, 64, 14, 0.88);
 }
 
 .status-completed {
-  color: #bbf7d0;
-  background: rgba(22, 163, 74, 0.16);
+  color: #f0fdf4;
+  background: rgba(21, 128, 61, 0.86);
 }
 
 .status-cancelled {
-  color: #fecaca;
-  background: rgba(220, 38, 38, 0.16);
+  color: #fff1f2;
+  background: rgba(153, 27, 27, 0.88);
 }
 
 .status-no-show {
-  color: #f5d0fe;
-  background: rgba(147, 51, 234, 0.16);
+  color: #faf5ff;
+  background: rgba(107, 33, 168, 0.88);
 }
 
 .empty-state {
@@ -878,9 +878,9 @@ async function submitBooking() {
   padding: 0.25rem 0.7rem;
   font-size: var(--font-size-xs);
   font-weight: var(--font-weight-semibold);
-  color: #fecaca;
-  background: rgba(220, 38, 38, 0.12);
-  border: 1px solid rgba(220, 38, 38, 0.3);
+  color: #fff1f2;
+  background: rgba(153, 27, 27, 0.78);
+  border: 1px solid rgba(248, 113, 113, 0.62);
   border-radius: var(--border-radius-full);
   cursor: pointer;
   transition:
@@ -889,8 +889,8 @@ async function submitBooking() {
 }
 
 .btn-cancel-appointment:hover {
-  background: rgba(220, 38, 38, 0.22);
-  border-color: rgba(220, 38, 38, 0.5);
+  background: rgba(185, 28, 28, 0.9);
+  border-color: rgba(252, 165, 165, 0.78);
 }
 
 @media (max-width: 960px) {


### PR DESCRIPTION
## Summary
- resolve the current unresolved SonarCloud findings across the notification, appointment, calendar, therapist, and dashboard code paths
- replace accessibility-role workarounds with semantic HTML and improve low-contrast therapist calendar and cancel actions
- reduce the oversized appointment builder parameter list and add focused frontend coverage for the accessibility fixes

## Validation
- cd backend && mvn -Dtest=AppointmentServiceTest,TherapistControllerTest test
- cd frontend && npm run test:unit -- --run src/components/__tests__/NotificationPanel.test.ts src/components/__tests__/AppointmentCancelModal.test.ts src/views/__tests__/TherapistCalendarView.test.ts src/components/dashboard/__tests__/VideoWidget.test.ts
- cd frontend && npm run lint -- src/components/NotificationPanel.vue src/components/AppointmentCancelModal.vue src/components/__tests__/NotificationPanel.test.ts src/components/__tests__/AppointmentCancelModal.test.ts src/views/TherapistCalendarView.vue src/components/dashboard/VideoWidget.vue
- cd frontend && npm run build

## Notes
- SonarCloud was reporting 12 unresolved findings for `lucasrudi_mindtrack` on March 21, 2026, even though the request referenced 13. This PR fixes the live unresolved set captured at that time.

Closes #355