### PR TITLE
feat(therapist): implement therapist-patient connection flow via invite link

### DIFF
--- a/backend/src/main/java/com/mindtrack/therapist/controller/PatientController.java
+++ b/backend/src/main/java/com/mindtrack/therapist/controller/PatientController.java
@@ -1,0 +1,60 @@
+package com.mindtrack.therapist.controller;
+
+import com.mindtrack.therapist.dto.TherapistRequestResponse;
+import com.mindtrack.therapist.service.PatientService;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST controller for patient-side therapist connection management.
+ *
+ * <p>All endpoints require authentication. Ownership is validated in the service layer.
+ */
+@RestController
+@RequestMapping("/api/patient/requests")
+public class PatientController {
+
+    private final PatientService patientService;
+
+    public PatientController(PatientService patientService) {
+        this.patientService = patientService;
+    }
+
+    /**
+     * Lists all pending and active therapist connection requests for the authenticated patient.
+     */
+    @GetMapping
+    public ResponseEntity<List<TherapistRequestResponse>> getRequests(
+            Authentication authentication) {
+        Long patientId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(patientService.getRequests(patientId));
+    }
+
+    /**
+     * Accepts a pending therapist connection request.
+     */
+    @PostMapping("/{id}/accept")
+    public ResponseEntity<Void> acceptRequest(
+            @PathVariable Long id, Authentication authentication) {
+        Long patientId = (Long) authentication.getPrincipal();
+        patientService.acceptRequest(id, patientId);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * Rejects a pending therapist connection request.
+     */
+    @PostMapping("/{id}/reject")
+    public ResponseEntity<Void> rejectRequest(
+            @PathVariable Long id, Authentication authentication) {
+        Long patientId = (Long) authentication.getPrincipal();
+        patientService.rejectRequest(id, patientId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/mindtrack/therapist/dto/TherapistRequestResponse.java
+++ b/backend/src/main/java/com/mindtrack/therapist/dto/TherapistRequestResponse.java
@@ -1,0 +1,68 @@
+package com.mindtrack.therapist.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * Response DTO for a patient's incoming therapist connection request.
+ */
+public class TherapistRequestResponse {
+
+    private Long relationshipId;
+    private Long therapistId;
+    private String therapistName;
+    private String therapistEmail;
+    private String status;
+    private LocalDateTime createdAt;
+
+    public TherapistRequestResponse() {
+        // Default constructor for JSON serialization.
+    }
+
+    public Long getRelationshipId() {
+        return relationshipId;
+    }
+
+    public void setRelationshipId(Long relationshipId) {
+        this.relationshipId = relationshipId;
+    }
+
+    public Long getTherapistId() {
+        return therapistId;
+    }
+
+    public void setTherapistId(Long therapistId) {
+        this.therapistId = therapistId;
+    }
+
+    public String getTherapistName() {
+        return therapistName;
+    }
+
+    public void setTherapistName(String therapistName) {
+        this.therapistName = therapistName;
+    }
+
+    public String getTherapistEmail() {
+        return therapistEmail;
+    }
+
+    public void setTherapistEmail(String therapistEmail) {
+        this.therapistEmail = therapistEmail;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/com/mindtrack/therapist/model/TherapistPatientStatus.java
+++ b/backend/src/main/java/com/mindtrack/therapist/model/TherapistPatientStatus.java
@@ -6,5 +6,6 @@ package com.mindtrack.therapist.model;
 public enum TherapistPatientStatus {
     PENDING,
     ACTIVE,
-    INACTIVE
+    INACTIVE,
+    EXPIRED
 }

--- a/backend/src/main/java/com/mindtrack/therapist/repository/InviteTokenRepository.java
+++ b/backend/src/main/java/com/mindtrack/therapist/repository/InviteTokenRepository.java
@@ -2,6 +2,7 @@ package com.mindtrack.therapist.repository;
 
 import com.mindtrack.therapist.model.InviteToken;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -17,6 +18,14 @@ public interface InviteTokenRepository extends JpaRepository<InviteToken, Long> 
 
     Optional<InviteToken> findByInitiatorIdAndRecipientIdAndUsedAtIsNullAndExpiresAtAfter(
             Long initiatorId, Long recipientId, LocalDateTime now);
+
+    /**
+     * Returns all expired tokens that have not been used yet.
+     * Used to identify stale PENDING therapist-patient relationships before cleanup.
+     *
+     * @param now the cutoff timestamp; tokens with expiresAt before this value are returned
+     */
+    List<InviteToken> findByExpiresAtBeforeAndUsedAtIsNull(LocalDateTime now);
 
     /**
      * Deletes all invite tokens that have expired before the given timestamp.

--- a/backend/src/main/java/com/mindtrack/therapist/repository/TherapistPatientRepository.java
+++ b/backend/src/main/java/com/mindtrack/therapist/repository/TherapistPatientRepository.java
@@ -17,4 +17,9 @@ public interface TherapistPatientRepository extends JpaRepository<TherapistPatie
 
     boolean existsByTherapistIdAndPatientIdAndStatus(Long therapistId, Long patientId,
                                                       TherapistPatientStatus status);
+
+    List<TherapistPatient> findByPatientIdAndStatusIn(Long patientId, List<TherapistPatientStatus> statuses);
+
+    Optional<TherapistPatient> findByTherapistIdAndPatientIdAndStatus(
+            Long therapistId, Long patientId, TherapistPatientStatus status);
 }

--- a/backend/src/main/java/com/mindtrack/therapist/service/InviteService.java
+++ b/backend/src/main/java/com/mindtrack/therapist/service/InviteService.java
@@ -13,6 +13,7 @@ import com.mindtrack.therapist.repository.TherapistPatientRepository;
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import java.util.HexFormat;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -80,7 +81,9 @@ public class InviteService {
         TherapistPatient relationship = therapistPatientRepository
                 .findByTherapistIdAndPatientId(therapistId, patient.getId())
                 .orElse(null);
-        if (relationship != null && relationship.getStatus() != TherapistPatientStatus.INACTIVE) {
+        if (relationship != null
+                && relationship.getStatus() != TherapistPatientStatus.INACTIVE
+                && relationship.getStatus() != TherapistPatientStatus.EXPIRED) {
             throw new IllegalArgumentException("Relationship already exists or is pending");
         }
 
@@ -158,14 +161,36 @@ public class InviteService {
     }
 
     /**
-     * Scheduled task that removes expired invite tokens from the database.
+     * Scheduled task that removes expired invite tokens and marks their associated
+     * PENDING therapist-patient relationships as EXPIRED.
      * Runs daily at 03:00 to keep the table free of stale rows.
      */
     @Scheduled(cron = "0 0 3 * * *")
     @Transactional
     public void cleanupExpiredTokens() {
-        inviteTokenRepository.deleteExpiredTokens(LocalDateTime.now());
-        LOG.info("Expired invite tokens cleaned up");
+        LocalDateTime now = LocalDateTime.now();
+
+        List<InviteToken> expiredTokens =
+                inviteTokenRepository.findByExpiresAtBeforeAndUsedAtIsNull(now);
+        int expiredCount = 0;
+        for (InviteToken expiredToken : expiredTokens) {
+            if (expiredToken.getRecipientId() != null) {
+                therapistPatientRepository
+                        .findByTherapistIdAndPatientIdAndStatus(
+                                expiredToken.getInitiatorId(),
+                                expiredToken.getRecipientId(),
+                                TherapistPatientStatus.PENDING)
+                        .ifPresent(relationship -> {
+                            relationship.setStatus(TherapistPatientStatus.EXPIRED);
+                            therapistPatientRepository.save(relationship);
+                        });
+                expiredCount++;
+            }
+        }
+
+        inviteTokenRepository.deleteExpiredTokens(now);
+        LOG.info("Expired invite tokens cleaned up; {} PENDING relationships marked EXPIRED",
+                expiredCount);
     }
 
     private InviteToken findValidToken(String token) {

--- a/backend/src/main/java/com/mindtrack/therapist/service/PatientService.java
+++ b/backend/src/main/java/com/mindtrack/therapist/service/PatientService.java
@@ -1,0 +1,101 @@
+package com.mindtrack.therapist.service;
+
+import com.mindtrack.auth.repository.UserRepository;
+import com.mindtrack.common.model.User;
+import com.mindtrack.therapist.dto.TherapistRequestResponse;
+import com.mindtrack.therapist.model.TherapistPatient;
+import com.mindtrack.therapist.model.TherapistPatientStatus;
+import com.mindtrack.therapist.repository.TherapistPatientRepository;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Service for patient-side therapist connection operations.
+ */
+@Service
+public class PatientService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PatientService.class);
+    private static final List<TherapistPatientStatus> VISIBLE_STATUSES =
+            List.of(TherapistPatientStatus.PENDING, TherapistPatientStatus.ACTIVE);
+
+    private final TherapistPatientRepository therapistPatientRepository;
+    private final UserRepository userRepository;
+
+    public PatientService(TherapistPatientRepository therapistPatientRepository,
+                          UserRepository userRepository) {
+        this.therapistPatientRepository = therapistPatientRepository;
+        this.userRepository = userRepository;
+    }
+
+    /**
+     * Returns all PENDING and ACTIVE therapist connection requests for the patient.
+     * EXPIRED and INACTIVE records are excluded.
+     */
+    public List<TherapistRequestResponse> getRequests(Long patientId) {
+        return therapistPatientRepository
+                .findByPatientIdAndStatusIn(patientId, VISIBLE_STATUSES)
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    /**
+     * Accepts a PENDING therapist connection request, transitioning it to ACTIVE.
+     *
+     * @throws IllegalArgumentException if the relationship is not found, not owned by this
+     *     patient, or not in PENDING status
+     */
+    @Transactional
+    public void acceptRequest(Long relationshipId, Long patientId) {
+        TherapistPatient relationship = findOwnedPendingRelationship(relationshipId, patientId);
+        relationship.setStatus(TherapistPatientStatus.ACTIVE);
+        therapistPatientRepository.save(relationship);
+        LOG.info("Patient {} accepted therapist request {}", patientId, relationshipId);
+    }
+
+    /**
+     * Rejects a PENDING therapist connection request, transitioning it to INACTIVE.
+     *
+     * @throws IllegalArgumentException if the relationship is not found, not owned by this
+     *     patient, or not in PENDING status
+     */
+    @Transactional
+    public void rejectRequest(Long relationshipId, Long patientId) {
+        TherapistPatient relationship = findOwnedPendingRelationship(relationshipId, patientId);
+        relationship.setStatus(TherapistPatientStatus.INACTIVE);
+        therapistPatientRepository.save(relationship);
+        LOG.info("Patient {} rejected therapist request {}", patientId, relationshipId);
+    }
+
+    private TherapistPatient findOwnedPendingRelationship(Long relationshipId, Long patientId) {
+        TherapistPatient relationship = therapistPatientRepository.findById(relationshipId)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Therapist request not found: " + relationshipId));
+        if (!relationship.getPatientId().equals(patientId)) {
+            throw new IllegalArgumentException("Therapist request does not belong to this patient");
+        }
+        if (relationship.getStatus() != TherapistPatientStatus.PENDING) {
+            throw new IllegalArgumentException(
+                    "Therapist request is not in PENDING status: " + relationship.getStatus());
+        }
+        return relationship;
+    }
+
+    private TherapistRequestResponse toResponse(TherapistPatient relationship) {
+        User therapist = userRepository.findById(relationship.getTherapistId())
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Therapist not found: " + relationship.getTherapistId()));
+        TherapistRequestResponse response = new TherapistRequestResponse();
+        response.setRelationshipId(relationship.getId());
+        response.setTherapistId(therapist.getId());
+        response.setTherapistName(therapist.getName());
+        response.setTherapistEmail(therapist.getEmail());
+        response.setStatus(relationship.getStatus().name());
+        response.setCreatedAt(relationship.getCreatedAt());
+        return response;
+    }
+}

--- a/backend/src/main/resources/db/migration/V27__add_expired_status_to_therapist_patients.sql
+++ b/backend/src/main/resources/db/migration/V27__add_expired_status_to_therapist_patients.sql
@@ -1,0 +1,3 @@
+-- V27__add_expired_status_to_therapist_patients.sql
+ALTER TABLE therapist_patients
+  MODIFY status ENUM('PENDING','ACTIVE','INACTIVE','EXPIRED') NOT NULL DEFAULT 'PENDING';

--- a/backend/src/test/java/com/mindtrack/therapist/controller/PatientControllerTest.java
+++ b/backend/src/test/java/com/mindtrack/therapist/controller/PatientControllerTest.java
@@ -1,0 +1,103 @@
+package com.mindtrack.therapist.controller;
+
+import com.mindtrack.therapist.dto.TherapistRequestResponse;
+import com.mindtrack.therapist.service.PatientService;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("local")
+class PatientControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private PatientService patientService;
+
+    private static UsernamePasswordAuthenticationToken userAuth() {
+        return new UsernamePasswordAuthenticationToken(
+                1L, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+    }
+
+    private static TherapistRequestResponse makeRequest(Long id, String status) {
+        TherapistRequestResponse r = new TherapistRequestResponse();
+        r.setRelationshipId(id);
+        r.setTherapistId(10L);
+        r.setTherapistName("Dr. Smith");
+        r.setTherapistEmail("drsmith@example.com");
+        r.setStatus(status);
+        r.setCreatedAt(LocalDateTime.of(2026, 1, 1, 10, 0));
+        return r;
+    }
+
+    @Test
+    void shouldListRequests() throws Exception {
+        when(patientService.getRequests(1L)).thenReturn(List.of(
+                makeRequest(1L, "PENDING"),
+                makeRequest(2L, "ACTIVE")
+        ));
+
+        mockMvc.perform(get("/api/patient/requests")
+                        .with(authentication(userAuth())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].status").value("PENDING"))
+                .andExpect(jsonPath("$[0].therapistName").value("Dr. Smith"))
+                .andExpect(jsonPath("$[1].status").value("ACTIVE"));
+    }
+
+    @Test
+    void shouldAcceptRequest() throws Exception {
+        doNothing().when(patientService).acceptRequest(5L, 1L);
+
+        mockMvc.perform(post("/api/patient/requests/5/accept")
+                        .with(authentication(userAuth())))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void shouldRejectRequest() throws Exception {
+        doNothing().when(patientService).rejectRequest(5L, 1L);
+
+        mockMvc.perform(post("/api/patient/requests/5/reject")
+                        .with(authentication(userAuth())))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void shouldReturn401ForUnauthenticatedRequests() throws Exception {
+        mockMvc.perform(get("/api/patient/requests"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void shouldReturn400WhenAcceptingNonPendingRequest() throws Exception {
+        doThrow(new IllegalArgumentException("Therapist request is not in PENDING status: ACTIVE"))
+                .when(patientService).acceptRequest(5L, 1L);
+
+        mockMvc.perform(post("/api/patient/requests/5/accept")
+                        .with(authentication(userAuth())))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/backend/src/test/java/com/mindtrack/therapist/service/InviteServiceTest.java
+++ b/backend/src/test/java/com/mindtrack/therapist/service/InviteServiceTest.java
@@ -11,6 +11,7 @@ import com.mindtrack.therapist.model.TherapistPatientStatus;
 import com.mindtrack.therapist.repository.InviteTokenRepository;
 import com.mindtrack.therapist.repository.TherapistPatientRepository;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,8 +25,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -161,6 +164,66 @@ class InviteServiceTest {
         ArgumentCaptor<TherapistPatient> captor = ArgumentCaptor.forClass(TherapistPatient.class);
         verify(therapistPatientRepository).save(captor.capture());
         assertEquals(TherapistPatientStatus.INACTIVE, captor.getValue().getStatus());
+    }
+
+    @Test
+    void cleanupShouldExpireStaleRelationshipsLinkedToExpiredTokens() {
+        InviteToken expiredToken = makeRequestToken(10L, 20L);
+        expiredToken.setExpiresAt(LocalDateTime.now().minusDays(1));
+        TherapistPatient pending = new TherapistPatient(10L, 20L, TherapistPatientStatus.PENDING);
+        when(inviteTokenRepository.findByExpiresAtBeforeAndUsedAtIsNull(any(LocalDateTime.class)))
+                .thenReturn(List.of(expiredToken));
+        when(therapistPatientRepository.findByTherapistIdAndPatientIdAndStatus(
+                10L, 20L, TherapistPatientStatus.PENDING)).thenReturn(Optional.of(pending));
+        when(therapistPatientRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        inviteService.cleanupExpiredTokens();
+
+        ArgumentCaptor<TherapistPatient> captor = ArgumentCaptor.forClass(TherapistPatient.class);
+        verify(therapistPatientRepository).save(captor.capture());
+        assertEquals(TherapistPatientStatus.EXPIRED, captor.getValue().getStatus());
+        verify(inviteTokenRepository).deleteExpiredTokens(any(LocalDateTime.class));
+    }
+
+    @Test
+    void cleanupShouldNotAffectRelationshipsWithNoExpiredTokens() {
+        when(inviteTokenRepository.findByExpiresAtBeforeAndUsedAtIsNull(any(LocalDateTime.class)))
+                .thenReturn(List.of());
+
+        assertDoesNotThrow(() -> inviteService.cleanupExpiredTokens());
+
+        verify(therapistPatientRepository, never()).save(any());
+        verify(inviteTokenRepository).deleteExpiredTokens(any(LocalDateTime.class));
+    }
+
+    @Test
+    void cleanupShouldSkipGenericTokensWithNoRecipient() {
+        InviteToken genericToken = makeToken(InitiatorRole.THERAPIST, 10L);
+        genericToken.setExpiresAt(LocalDateTime.now().minusDays(1));
+        when(inviteTokenRepository.findByExpiresAtBeforeAndUsedAtIsNull(any(LocalDateTime.class)))
+                .thenReturn(List.of(genericToken));
+
+        inviteService.cleanupExpiredTokens();
+
+        verify(therapistPatientRepository, never()).findByTherapistIdAndPatientIdAndStatus(
+                any(), any(), any());
+        verify(inviteTokenRepository).deleteExpiredTokens(any(LocalDateTime.class));
+    }
+
+    @Test
+    void shouldAllowNewRequestAfterExpiredRelationship() {
+        User patient = makeUser(20L, "Patient One");
+        patient.setEmail("patient@test.com");
+        TherapistPatient expired = new TherapistPatient(10L, 20L, TherapistPatientStatus.EXPIRED);
+        when(userRepository.findByEmail("patient@test.com")).thenReturn(Optional.of(patient));
+        when(therapistPatientRepository.findByTherapistIdAndPatientId(10L, 20L))
+                .thenReturn(Optional.of(expired));
+        when(inviteTokenRepository.findByInitiatorIdAndRecipientIdAndUsedAtIsNullAndExpiresAtAfter(
+                eq(10L), eq(20L), any(LocalDateTime.class))).thenReturn(Optional.empty());
+        when(therapistPatientRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(inviteTokenRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        assertDoesNotThrow(() -> inviteService.requestPatient(10L, "patient@test.com"));
     }
 
     private InviteToken makeToken(InitiatorRole role, Long initiatorId) {

--- a/backend/src/test/java/com/mindtrack/therapist/service/PatientServiceTest.java
+++ b/backend/src/test/java/com/mindtrack/therapist/service/PatientServiceTest.java
@@ -1,0 +1,136 @@
+package com.mindtrack.therapist.service;
+
+import com.mindtrack.auth.repository.UserRepository;
+import com.mindtrack.common.model.User;
+import com.mindtrack.therapist.dto.TherapistRequestResponse;
+import com.mindtrack.therapist.model.TherapistPatient;
+import com.mindtrack.therapist.model.TherapistPatientStatus;
+import com.mindtrack.therapist.repository.TherapistPatientRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PatientServiceTest {
+
+    @Mock private TherapistPatientRepository therapistPatientRepository;
+    @Mock private UserRepository userRepository;
+
+    private PatientService patientService;
+
+    @BeforeEach
+    void setUp() {
+        patientService = new PatientService(therapistPatientRepository, userRepository);
+    }
+
+    @Test
+    void getRequestsShouldReturnPendingAndActiveOnly() {
+        TherapistPatient pending = makeRelationship(1L, 10L, 20L, TherapistPatientStatus.PENDING);
+        TherapistPatient active = makeRelationship(2L, 11L, 20L, TherapistPatientStatus.ACTIVE);
+        User therapist1 = makeUser(10L, "Dr. Smith", "smith@example.com");
+        User therapist2 = makeUser(11L, "Dr. Jones", "jones@example.com");
+        when(therapistPatientRepository.findByPatientIdAndStatusIn(eq(20L), any()))
+                .thenReturn(List.of(pending, active));
+        when(userRepository.findById(10L)).thenReturn(Optional.of(therapist1));
+        when(userRepository.findById(11L)).thenReturn(Optional.of(therapist2));
+
+        List<TherapistRequestResponse> result = patientService.getRequests(20L);
+
+        assertEquals(2, result.size());
+        assertEquals("PENDING", result.get(0).getStatus());
+        assertEquals("Dr. Smith", result.get(0).getTherapistName());
+        assertEquals("ACTIVE", result.get(1).getStatus());
+        assertEquals("Dr. Jones", result.get(1).getTherapistName());
+    }
+
+    @Test
+    void getRequestsShouldReturnEmptyListWhenNoRequests() {
+        when(therapistPatientRepository.findByPatientIdAndStatusIn(eq(20L), any()))
+                .thenReturn(List.of());
+
+        List<TherapistRequestResponse> result = patientService.getRequests(20L);
+
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    void acceptRequestShouldTransitionPendingToActive() {
+        TherapistPatient pending = makeRelationship(1L, 10L, 20L, TherapistPatientStatus.PENDING);
+        when(therapistPatientRepository.findById(1L)).thenReturn(Optional.of(pending));
+        when(therapistPatientRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        patientService.acceptRequest(1L, 20L);
+
+        ArgumentCaptor<TherapistPatient> captor = ArgumentCaptor.forClass(TherapistPatient.class);
+        verify(therapistPatientRepository).save(captor.capture());
+        assertEquals(TherapistPatientStatus.ACTIVE, captor.getValue().getStatus());
+    }
+
+    @Test
+    void rejectRequestShouldTransitionPendingToInactive() {
+        TherapistPatient pending = makeRelationship(1L, 10L, 20L, TherapistPatientStatus.PENDING);
+        when(therapistPatientRepository.findById(1L)).thenReturn(Optional.of(pending));
+        when(therapistPatientRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        patientService.rejectRequest(1L, 20L);
+
+        ArgumentCaptor<TherapistPatient> captor = ArgumentCaptor.forClass(TherapistPatient.class);
+        verify(therapistPatientRepository).save(captor.capture());
+        assertEquals(TherapistPatientStatus.INACTIVE, captor.getValue().getStatus());
+    }
+
+    @Test
+    void acceptRequestShouldThrowWhenRelationshipNotFound() {
+        when(therapistPatientRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> patientService.acceptRequest(99L, 20L));
+    }
+
+    @Test
+    void acceptRequestShouldThrowWhenPatientDoesNotOwnRelationship() {
+        TherapistPatient pending = makeRelationship(1L, 10L, 20L, TherapistPatientStatus.PENDING);
+        when(therapistPatientRepository.findById(1L)).thenReturn(Optional.of(pending));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> patientService.acceptRequest(1L, 99L));
+    }
+
+    @Test
+    void acceptRequestShouldThrowWhenRelationshipNotPending() {
+        TherapistPatient active = makeRelationship(1L, 10L, 20L, TherapistPatientStatus.ACTIVE);
+        when(therapistPatientRepository.findById(1L)).thenReturn(Optional.of(active));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> patientService.acceptRequest(1L, 20L));
+    }
+
+    private static TherapistPatient makeRelationship(Long id, Long therapistId, Long patientId,
+                                                     TherapistPatientStatus status) {
+        TherapistPatient r = new TherapistPatient(therapistId, patientId, status);
+        r.setId(id);
+        r.setCreatedAt(LocalDateTime.of(2026, 1, 1, 10, 0));
+        return r;
+    }
+
+    private static User makeUser(Long id, String name, String email) {
+        User u = new User();
+        u.setId(id);
+        u.setName(name);
+        u.setEmail(email);
+        return u;
+    }
+}

--- a/frontend/src/components/dashboard/TherapistRequestsWidget.vue
+++ b/frontend/src/components/dashboard/TherapistRequestsWidget.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { TherapistRequest } from '@/stores/patient'
+
+const props = defineProps<{
+  requests: TherapistRequest[]
+  loading: boolean
+}>()
+
+const emit = defineEmits<{
+  accept: [relationshipId: number]
+  reject: [relationshipId: number]
+}>()
+
+const pendingRequests = computed(() => props.requests.filter((r) => r.status === 'PENDING'))
+const activeConnections = computed(() => props.requests.filter((r) => r.status === 'ACTIVE'))
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+</script>
+
+<template>
+  <section class="therapist-requests-widget" data-testid="therapist-requests-widget">
+    <h2 class="widget-title">Therapist Connections</h2>
+
+    <div v-if="loading" class="loading-state">
+      <p>Loading therapist requests...</p>
+    </div>
+
+    <template v-else>
+      <div v-if="activeConnections.length" class="connections-section">
+        <p class="section-label">Connected</p>
+        <div
+          v-for="conn in activeConnections"
+          :key="conn.relationshipId"
+          class="connection-card connection-card--active"
+          data-testid="active-connection"
+        >
+          <div class="connection-info">
+            <span class="therapist-name">{{ conn.therapistName }}</span>
+            <span class="therapist-email">{{ conn.therapistEmail }}</span>
+          </div>
+          <span class="status-badge status-active">Active</span>
+        </div>
+      </div>
+
+      <div v-if="pendingRequests.length" class="connections-section">
+        <p class="section-label">Pending Requests</p>
+        <div
+          v-for="req in pendingRequests"
+          :key="req.relationshipId"
+          class="connection-card connection-card--pending"
+          data-testid="pending-request"
+        >
+          <div class="connection-info">
+            <span class="therapist-name">{{ req.therapistName }}</span>
+            <span class="therapist-email">{{ req.therapistEmail }}</span>
+            <span class="request-date">Requested {{ formatDate(req.createdAt) }}</span>
+          </div>
+          <div class="action-buttons">
+            <button
+              class="btn btn-primary btn-sm"
+              data-testid="accept-btn"
+              @click="emit('accept', req.relationshipId)"
+            >
+              Accept
+            </button>
+            <button
+              class="btn btn-secondary btn-sm"
+              data-testid="reject-btn"
+              @click="emit('reject', req.relationshipId)"
+            >
+              Reject
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div
+        v-if="!activeConnections.length && !pendingRequests.length"
+        class="empty-state"
+        data-testid="empty-state"
+      >
+        <p>No therapist connections yet.</p>
+      </div>
+    </template>
+  </section>
+</template>

--- a/frontend/src/components/dashboard/__tests__/TherapistRequestsWidget.test.ts
+++ b/frontend/src/components/dashboard/__tests__/TherapistRequestsWidget.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import TherapistRequestsWidget from '../TherapistRequestsWidget.vue'
+import type { TherapistRequest } from '@/stores/patient'
+
+function makeRequest(overrides: Partial<TherapistRequest> = {}): TherapistRequest {
+  return {
+    relationshipId: 1,
+    therapistId: 10,
+    therapistName: 'Dr. Smith',
+    therapistEmail: 'smith@example.com',
+    status: 'PENDING',
+    createdAt: '2026-01-01T10:00:00',
+    ...overrides,
+  }
+}
+
+describe('TherapistRequestsWidget', () => {
+  it('shows empty state when no requests', () => {
+    const wrapper = mount(TherapistRequestsWidget, {
+      props: { requests: [], loading: false },
+    })
+    expect(wrapper.find('[data-testid="empty-state"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="pending-request"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="active-connection"]').exists()).toBe(false)
+  })
+
+  it('renders pending requests with accept and reject buttons', () => {
+    const wrapper = mount(TherapistRequestsWidget, {
+      props: { requests: [makeRequest({ status: 'PENDING' })], loading: false },
+    })
+    const pending = wrapper.find('[data-testid="pending-request"]')
+    expect(pending.exists()).toBe(true)
+    expect(pending.text()).toContain('Dr. Smith')
+    expect(pending.text()).toContain('smith@example.com')
+    expect(wrapper.find('[data-testid="accept-btn"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="reject-btn"]').exists()).toBe(true)
+  })
+
+  it('renders active connections without action buttons', () => {
+    const wrapper = mount(TherapistRequestsWidget, {
+      props: { requests: [makeRequest({ status: 'ACTIVE' })], loading: false },
+    })
+    const active = wrapper.find('[data-testid="active-connection"]')
+    expect(active.exists()).toBe(true)
+    expect(active.text()).toContain('Dr. Smith')
+    expect(wrapper.find('[data-testid="accept-btn"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="reject-btn"]').exists()).toBe(false)
+  })
+
+  it('emits accept event with relationshipId when accept is clicked', async () => {
+    const wrapper = mount(TherapistRequestsWidget, {
+      props: { requests: [makeRequest({ relationshipId: 42, status: 'PENDING' })], loading: false },
+    })
+    await wrapper.find('[data-testid="accept-btn"]').trigger('click')
+    expect(wrapper.emitted('accept')).toEqual([[42]])
+  })
+
+  it('emits reject event with relationshipId when reject is clicked', async () => {
+    const wrapper = mount(TherapistRequestsWidget, {
+      props: { requests: [makeRequest({ relationshipId: 7, status: 'PENDING' })], loading: false },
+    })
+    await wrapper.find('[data-testid="reject-btn"]').trigger('click')
+    expect(wrapper.emitted('reject')).toEqual([[7]])
+  })
+
+  it('shows loading state', () => {
+    const wrapper = mount(TherapistRequestsWidget, {
+      props: { requests: [], loading: true },
+    })
+    expect(wrapper.find('.loading-state').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="empty-state"]').exists()).toBe(false)
+  })
+
+  it('does not show empty state when loading', () => {
+    const wrapper = mount(TherapistRequestsWidget, {
+      props: { requests: [], loading: true },
+    })
+    expect(wrapper.find('[data-testid="empty-state"]').exists()).toBe(false)
+  })
+})

--- a/frontend/src/stores/__tests__/patient.test.ts
+++ b/frontend/src/stores/__tests__/patient.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { usePatientStore } from '../patient'
+
+const mockRequests = [
+  {
+    relationshipId: 1,
+    therapistId: 10,
+    therapistName: 'Dr. Smith',
+    therapistEmail: 'smith@example.com',
+    status: 'PENDING',
+    createdAt: '2026-01-01T10:00:00',
+  },
+  {
+    relationshipId: 2,
+    therapistId: 11,
+    therapistName: 'Dr. Jones',
+    therapistEmail: 'jones@example.com',
+    status: 'ACTIVE',
+    createdAt: '2026-01-02T10:00:00',
+  },
+]
+
+vi.mock('@/services/api', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}))
+
+describe('usePatientStore', () => {
+  let api: {
+    get: ReturnType<typeof vi.fn>
+    post: ReturnType<typeof vi.fn>
+  }
+
+  beforeEach(async () => {
+    setActivePinia(createPinia())
+    const module = await import('@/services/api')
+    api = module.default as unknown as typeof api
+    vi.clearAllMocks()
+  })
+
+  describe('fetchRequests', () => {
+    it('fetches therapist requests', async () => {
+      api.get.mockResolvedValueOnce({ data: mockRequests })
+      const store = usePatientStore()
+
+      await store.fetchRequests()
+
+      expect(api.get).toHaveBeenCalledWith('/patient/requests')
+      expect(store.requests).toEqual(mockRequests)
+      expect(store.loading).toBe(false)
+      expect(store.error).toBeNull()
+    })
+
+    it('sets loading state during fetch', async () => {
+      let resolve: (value: unknown) => void
+      const promise = new Promise((r) => {
+        resolve = r
+      })
+      api.get.mockReturnValueOnce(promise)
+      const store = usePatientStore()
+
+      const fetchPromise = store.fetchRequests()
+      expect(store.loading).toBe(true)
+
+      resolve!({ data: mockRequests })
+      await fetchPromise
+      expect(store.loading).toBe(false)
+    })
+
+    it('sets error on failure', async () => {
+      api.get.mockRejectedValueOnce(new Error('Network error'))
+      const store = usePatientStore()
+
+      await store.fetchRequests()
+
+      expect(store.error).toBe('Failed to load therapist requests')
+      expect(store.loading).toBe(false)
+    })
+  })
+
+  describe('acceptRequest', () => {
+    it('updates status to ACTIVE locally on success', async () => {
+      api.get.mockResolvedValueOnce({ data: mockRequests })
+      api.post.mockResolvedValueOnce({})
+      const store = usePatientStore()
+      await store.fetchRequests()
+
+      await store.acceptRequest(1)
+
+      expect(api.post).toHaveBeenCalledWith('/patient/requests/1/accept')
+      const updated = store.requests.find((r) => r.relationshipId === 1)
+      expect(updated?.status).toBe('ACTIVE')
+    })
+
+    it('sets error and rethrows on failure', async () => {
+      api.get.mockResolvedValueOnce({ data: mockRequests })
+      api.post.mockRejectedValueOnce(new Error('Server error'))
+      const store = usePatientStore()
+      await store.fetchRequests()
+
+      await expect(store.acceptRequest(1)).rejects.toThrow()
+      expect(store.error).toBe('Failed to accept request')
+    })
+  })
+
+  describe('rejectRequest', () => {
+    it('removes the request locally on success', async () => {
+      api.get.mockResolvedValueOnce({ data: mockRequests })
+      api.post.mockResolvedValueOnce({})
+      const store = usePatientStore()
+      await store.fetchRequests()
+
+      await store.rejectRequest(1)
+
+      expect(api.post).toHaveBeenCalledWith('/patient/requests/1/reject')
+      expect(store.requests.find((r) => r.relationshipId === 1)).toBeUndefined()
+      expect(store.requests).toHaveLength(1)
+    })
+
+    it('sets error and rethrows on failure', async () => {
+      api.get.mockResolvedValueOnce({ data: mockRequests })
+      api.post.mockRejectedValueOnce(new Error('Server error'))
+      const store = usePatientStore()
+      await store.fetchRequests()
+
+      await expect(store.rejectRequest(1)).rejects.toThrow()
+      expect(store.error).toBe('Failed to reject request')
+    })
+  })
+
+  describe('clearError', () => {
+    it('clears the error state', async () => {
+      api.get.mockRejectedValueOnce(new Error('error'))
+      const store = usePatientStore()
+      await store.fetchRequests()
+      expect(store.error).not.toBeNull()
+
+      store.clearError()
+      expect(store.error).toBeNull()
+    })
+  })
+})

--- a/frontend/src/stores/patient.ts
+++ b/frontend/src/stores/patient.ts
@@ -1,0 +1,69 @@
+import { ref } from 'vue'
+import { defineStore } from 'pinia'
+import api from '@/services/api'
+
+export interface TherapistRequest {
+  relationshipId: number
+  therapistId: number
+  therapistName: string
+  therapistEmail: string
+  status: string
+  createdAt: string
+}
+
+export const usePatientStore = defineStore('patient', () => {
+  const requests = ref<TherapistRequest[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function fetchRequests() {
+    loading.value = true
+    error.value = null
+    try {
+      const response = await api.get('/patient/requests')
+      requests.value = response.data
+    } catch {
+      error.value = 'Failed to load therapist requests'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function acceptRequest(relationshipId: number) {
+    error.value = null
+    try {
+      await api.post(`/patient/requests/${relationshipId}/accept`)
+      requests.value = requests.value.map((r) =>
+        r.relationshipId === relationshipId ? { ...r, status: 'ACTIVE' } : r,
+      )
+    } catch {
+      error.value = 'Failed to accept request'
+      throw new Error('Failed to accept request')
+    }
+  }
+
+  async function rejectRequest(relationshipId: number) {
+    error.value = null
+    try {
+      await api.post(`/patient/requests/${relationshipId}/reject`)
+      requests.value = requests.value.filter((r) => r.relationshipId !== relationshipId)
+    } catch {
+      error.value = 'Failed to reject request'
+      throw new Error('Failed to reject request')
+    }
+  }
+
+  function clearError() {
+    error.value = null
+  }
+
+  return {
+    requests,
+    loading,
+    error,
+    fetchRequests,
+    acceptRequest,
+    rejectRequest,
+    clearError,
+  }
+})

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, ref, watch } from 'vue'
 import { useAnalyticsStore } from '@/stores/analytics'
 import { useProfileStore } from '@/stores/profile'
 import { useGoalsStore } from '@/stores/goals'
+import { usePatientStore } from '@/stores/patient'
 import { useTutorial } from '@/composables/useTutorial'
 import MoodTrendChart from '@/components/charts/MoodTrendChart.vue'
 import ActivityCompletionChart from '@/components/charts/ActivityCompletionChart.vue'
@@ -15,10 +16,12 @@ import MoodEntryWidget from '@/components/dashboard/MoodEntryWidget.vue'
 import ResourcesWidget from '@/components/dashboard/ResourcesWidget.vue'
 import WellbeingWidget from '@/components/dashboard/WellbeingWidget.vue'
 import VideoWidget from '@/components/dashboard/VideoWidget.vue'
+import TherapistRequestsWidget from '@/components/dashboard/TherapistRequestsWidget.vue'
 
 const store = useAnalyticsStore()
 const profileStore = useProfileStore()
 const goalsStore = useGoalsStore()
+const patientStore = usePatientStore()
 const { start: startTutorial } = useTutorial()
 const surveyPromptDismissed = ref(sessionStorage.getItem('surveyPromptDismissed') === 'true')
 
@@ -69,9 +72,25 @@ const wellbeingItems = computed(() =>
 )
 const videoItems = computed(() => store.contentItems.filter((i) => i.type === 'VIDEO'))
 
+async function handleAcceptRequest(relationshipId: number) {
+  try {
+    await patientStore.acceptRequest(relationshipId)
+  } catch {
+    // Error state handled by store
+  }
+}
+
+async function handleRejectRequest(relationshipId: number) {
+  try {
+    await patientStore.rejectRequest(relationshipId)
+  } catch {
+    // Error state handled by store
+  }
+}
+
 onMounted(async () => {
   try {
-    await Promise.all([store.fetchAll(), goalsStore.fetchGoals()])
+    await Promise.all([store.fetchAll(), goalsStore.fetchGoals(), patientStore.fetchRequests()])
   } catch {
     // Error state handled by store
   }
@@ -147,6 +166,19 @@ watch(
       <p>{{ store.error }}</p>
       <button class="btn btn-secondary btn-sm" @click="store.clearError()">Dismiss</button>
     </div>
+
+    <section
+      v-if="patientStore.requests.length || patientStore.loading"
+      class="dashboard-section"
+      data-testid="therapist-requests-section"
+    >
+      <TherapistRequestsWidget
+        :requests="patientStore.requests"
+        :loading="patientStore.loading"
+        @accept="handleAcceptRequest"
+        @reject="handleRejectRequest"
+      />
+    </section>
 
     <div v-if="store.loading" class="loading">
       <p>Loading your dashboard...</p>

--- a/frontend/src/views/TherapistView.vue
+++ b/frontend/src/views/TherapistView.vue
@@ -8,6 +8,7 @@ const requestEmail = ref('')
 const requestLink = ref<string | null>(null)
 const requestMessage = ref<string | null>(null)
 const requesting = ref(false)
+const copyFeedback = ref(false)
 const selectedPatientId = ref<number | null>(null)
 
 const overviewCards = computed(() => {
@@ -159,6 +160,19 @@ function isSelectedPatient(patientId: number): boolean {
   return selectedPatientId.value === patientId
 }
 
+async function copyLink() {
+  if (!requestLink.value) return
+  try {
+    await navigator.clipboard.writeText(requestLink.value)
+    copyFeedback.value = true
+    setTimeout(() => {
+      copyFeedback.value = false
+    }, 2000)
+  } catch {
+    copyFeedback.value = false
+  }
+}
+
 function formatDate(dateStr: string | null): string {
   if (!dateStr) return '-'
   const date = new Date(dateStr)
@@ -228,9 +242,12 @@ function statusClass(status: string): string {
         </button>
       </div>
       <p v-if="requestMessage" class="request-message">{{ requestMessage }}</p>
-      <a v-if="requestLink" class="request-link" :href="requestLink" target="_blank">
-        Open request link
-      </a>
+      <div v-if="requestLink" class="request-link-row">
+        <a class="request-link" :href="requestLink" target="_blank">Open request link</a>
+        <button class="btn btn-secondary btn-sm" data-testid="copy-link-btn" @click="copyLink">
+          {{ copyFeedback ? 'Copied!' : 'Copy link' }}
+        </button>
+      </div>
     </section>
 
     <section v-if="!store.currentPatient" class="pending-panel">

--- a/frontend/src/views/__tests__/TherapistView.test.ts
+++ b/frontend/src/views/__tests__/TherapistView.test.ts
@@ -233,4 +233,29 @@ describe('TherapistView', () => {
     expect(wrapper.find('.error-message').exists()).toBe(true)
     expect(wrapper.find('.error-message').text()).toContain('Failed to load patients')
   })
+
+  it('shows copy link button after sending a request and copies to clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+
+    mockGet.mockResolvedValueOnce({ data: mockPatients })
+    mockGet.mockResolvedValueOnce({ data: mockPendingPatients })
+    const wrapper = mount(TherapistView)
+    await flushPromises()
+
+    const requestInput = wrapper.find('input[type="email"]')
+    await requestInput.setValue('newpatient@test.com')
+    await wrapper.find('.request-panel .btn-primary').trigger('click')
+    await flushPromises()
+
+    const copyBtn = wrapper.find('[data-testid="copy-link-btn"]')
+    expect(copyBtn.exists()).toBe(true)
+    expect(copyBtn.text()).toBe('Copy link')
+
+    await copyBtn.trigger('click')
+    await flushPromises()
+
+    expect(writeText).toHaveBeenCalledWith('http://localhost:3000/invite/request-token')
+    expect(copyBtn.text()).toBe('Copied!')
+  })
 })


### PR DESCRIPTION
## Summary

- Add `GET /api/patient/requests` + accept/reject endpoints via new `PatientController` and `PatientService`
- Add patient-side frontend: `usePatientStore`, `TherapistRequestsWidget` integrated into `DashboardView`
- Extend `cleanupExpiredTokens` to mark stale PENDING relationships as `EXPIRED` (new enum value + V27 migration)
- Add copy-to-clipboard button for invite URL in therapist dashboard

## Test Plan

- [x] `mvn clean verify` — 549 tests, 0 failures
- [x] `npm run lint && npm run test:unit` — 572 tests, 0 failures, lint clean
- [x] `PatientControllerTest` — covers GET/accept/reject + 401 unauthenticated + 400 non-pending
- [x] `PatientServiceTest` — ownership check, status transition, excludes EXPIRED from list
- [x] `InviteServiceTest` — cleanup expiry logic, skips generic tokens, allows re-request after EXPIRED
- [x] `TherapistRequestsWidget.test.ts` — pending/active rendering, accept/reject emit, empty state, loading
- [x] `patient.test.ts` — fetch/accept/reject actions, error handling
- [x] `TherapistView.test.ts` — copy-to-clipboard shows "Copied!" feedback

Closes #354