### PR TITLE
test(messaging): improve backend coverage

### DIFF
--- a/backend/src/main/java/com/mindtrack/messaging/service/TelegramService.java
+++ b/backend/src/main/java/com/mindtrack/messaging/service/TelegramService.java
@@ -8,6 +8,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 /**
@@ -27,9 +28,14 @@ public class TelegramService {
      *
      * @param properties messaging configuration
      */
+    @Autowired
     public TelegramService(MessagingProperties properties) {
+        this(properties, HttpClient.newHttpClient());
+    }
+
+    TelegramService(MessagingProperties properties, HttpClient httpClient) {
         this.properties = properties;
-        this.httpClient = HttpClient.newHttpClient();
+        this.httpClient = httpClient;
     }
 
     /**

--- a/backend/src/main/java/com/mindtrack/messaging/service/WhatsAppService.java
+++ b/backend/src/main/java/com/mindtrack/messaging/service/WhatsAppService.java
@@ -8,6 +8,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
@@ -29,9 +30,14 @@ public class WhatsAppService {
      *
      * @param properties messaging configuration
      */
+    @Autowired
     public WhatsAppService(MessagingProperties properties) {
+        this(properties, HttpClient.newHttpClient());
+    }
+
+    WhatsAppService(MessagingProperties properties, HttpClient httpClient) {
         this.properties = properties;
-        this.httpClient = HttpClient.newHttpClient();
+        this.httpClient = httpClient;
     }
 
     /**

--- a/backend/src/test/java/com/mindtrack/messaging/service/TelegramServiceTest.java
+++ b/backend/src/test/java/com/mindtrack/messaging/service/TelegramServiceTest.java
@@ -1,0 +1,160 @@
+package com.mindtrack.messaging.service;
+
+import com.mindtrack.messaging.config.MessagingProperties;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Flow;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TelegramServiceTest {
+
+    @Mock
+    private HttpClient httpClient;
+
+    @Mock
+    private HttpResponse<String> response;
+
+    @Test
+    void shouldSkipSendWhenTelegramTokenIsBlank() throws Exception {
+        TelegramService service = new TelegramService(propertiesWithTelegramToken("   "), httpClient);
+
+        service.sendMessage("12345", "Hello");
+
+        verify(httpClient, never()).send(any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any());
+    }
+
+    @Test
+    void shouldSkipSendWhenTelegramTokenIsNull() throws Exception {
+        TelegramService service = new TelegramService(propertiesWithTelegramToken(null), httpClient);
+
+        service.sendMessage("12345", "Hello");
+
+        verify(httpClient, never()).send(any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any());
+    }
+
+    @Test
+    void shouldSendTelegramMessageWithEscapedPayload() throws Exception {
+        TelegramService service = new TelegramService(propertiesWithTelegramToken("bot-token"), httpClient);
+        when(response.statusCode()).thenReturn(200);
+        when(httpClient.send(any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+                .thenReturn(response);
+
+        service.sendMessage("chat-\"1", "Line 1\nTabbed\t\\\\quoted\"");
+
+        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(httpClient).send(requestCaptor.capture(), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any());
+
+        HttpRequest request = requestCaptor.getValue();
+        assertEquals(URI.create("https://api.telegram.org/botbot-token/sendMessage"), request.uri());
+        assertEquals("application/json", request.headers().firstValue("Content-Type").orElseThrow());
+        assertEquals(
+                "{\"chat_id\":\"chat-\\\"1\",\"text\":\"Line 1\\nTabbed\\t\\\\\\\\quoted\\\"\",\"parse_mode\":\"Markdown\"}",
+                requestBody(request));
+    }
+
+    @Test
+    void shouldTreatNon200TelegramResponseAsHandled() throws Exception {
+        TelegramService service = new TelegramService(propertiesWithTelegramToken("bot-token"), httpClient);
+        when(response.statusCode()).thenReturn(500);
+        when(response.body()).thenReturn("bad request");
+        when(httpClient.send(any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+                .thenReturn(response);
+
+        service.sendMessage("12345", null);
+
+        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(httpClient).send(requestCaptor.capture(), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any());
+        assertEquals(
+                "{\"chat_id\":\"12345\",\"text\":\"\",\"parse_mode\":\"Markdown\"}",
+                requestBody(requestCaptor.getValue()));
+    }
+
+    @Test
+    void shouldRestoreInterruptedFlagWhenTelegramSendIsInterrupted() throws Exception {
+        TelegramService service = new TelegramService(propertiesWithTelegramToken("bot-token"), httpClient);
+        when(httpClient.send(any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+                .thenThrow(new InterruptedException("interrupted"));
+
+        assertFalse(Thread.currentThread().isInterrupted());
+
+        service.sendMessage("12345", "Hello");
+
+        assertTrue(Thread.currentThread().isInterrupted());
+        Thread.interrupted();
+    }
+
+    @Test
+    void shouldSwallowTelegramIoExceptions() throws Exception {
+        TelegramService service = new TelegramService(propertiesWithTelegramToken("bot-token"), httpClient);
+        when(httpClient.send(any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+                .thenThrow(new IOException("network down"));
+
+        service.sendMessage("12345", "Hello");
+
+        verify(httpClient).send(any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any());
+    }
+
+    private MessagingProperties propertiesWithTelegramToken(String token) {
+        MessagingProperties properties = new MessagingProperties();
+        properties.getTelegram().setBotToken(token);
+        return properties;
+    }
+
+    private String requestBody(HttpRequest request) throws Exception {
+        HttpRequest.BodyPublisher publisher = request.bodyPublisher().orElseThrow();
+        BodyCollector subscriber = new BodyCollector();
+        publisher.subscribe(subscriber);
+        return subscriber.body();
+    }
+
+    private static final class BodyCollector implements Flow.Subscriber<ByteBuffer> {
+
+        private final StringBuilder body = new StringBuilder();
+        private final CompletableFuture<Void> done = new CompletableFuture<>();
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            subscription.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(ByteBuffer item) {
+            body.append(StandardCharsets.UTF_8.decode(item.duplicate()));
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            done.completeExceptionally(throwable);
+        }
+
+        @Override
+        public void onComplete() {
+            done.complete(null);
+        }
+
+        private String body() throws Exception {
+            done.get();
+            return body.toString();
+        }
+    }
+}

--- a/backend/src/test/java/com/mindtrack/messaging/service/WhatsAppServiceTest.java
+++ b/backend/src/test/java/com/mindtrack/messaging/service/WhatsAppServiceTest.java
@@ -1,0 +1,164 @@
+package com.mindtrack.messaging.service;
+
+import com.mindtrack.messaging.config.MessagingProperties;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Flow;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WhatsAppServiceTest {
+
+    @Mock
+    private HttpClient httpClient;
+
+    @Mock
+    private HttpResponse<String> response;
+
+    @Test
+    void shouldSkipSendWhenWhatsappTokenIsBlank() throws Exception {
+        WhatsAppService service = new WhatsAppService(properties("   ", "phone-id"), httpClient);
+
+        service.sendMessage("34600111222", "Hello");
+
+        verify(httpClient, never()).send(any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any());
+    }
+
+    @Test
+    void shouldSkipSendWhenWhatsappTokenIsNull() throws Exception {
+        WhatsAppService service = new WhatsAppService(properties(null, "phone-id"), httpClient);
+
+        service.sendMessage("34600111222", "Hello");
+
+        verify(httpClient, never()).send(any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any());
+    }
+
+    @Test
+    void shouldSendWhatsappMessageWithEscapedPayloadAndAuthHeader() throws Exception {
+        WhatsAppService service = new WhatsAppService(properties("api-token", "phone-id"), httpClient);
+        when(response.statusCode()).thenReturn(200);
+        when(httpClient.send(any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+                .thenReturn(response);
+
+        service.sendMessage("34600\"111222", "Line 1\nTabbed\t\\\\quoted\"");
+
+        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(httpClient).send(requestCaptor.capture(), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any());
+
+        HttpRequest request = requestCaptor.getValue();
+        assertEquals(URI.create("https://graph.facebook.com/v18.0/phone-id/messages"), request.uri());
+        assertEquals("application/json", request.headers().firstValue("Content-Type").orElseThrow());
+        assertEquals("Bearer api-token", request.headers().firstValue("Authorization").orElseThrow());
+        assertEquals(
+                "{\"messaging_product\":\"whatsapp\",\"to\":\"34600\\\"111222\","
+                        + "\"type\":\"text\",\"text\":{\"body\":\"Line 1\\nTabbed\\t\\\\\\\\quoted\\\"\"}}",
+                requestBody(request));
+    }
+
+    @Test
+    void shouldTreatNon200WhatsappResponseAsHandled() throws Exception {
+        WhatsAppService service = new WhatsAppService(properties("api-token", "phone-id"), httpClient);
+        when(response.statusCode()).thenReturn(400);
+        when(response.body()).thenReturn("bad request");
+        when(httpClient.send(any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+                .thenReturn(response);
+
+        service.sendMessage("34600111222", null);
+
+        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(httpClient).send(requestCaptor.capture(), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any());
+        assertEquals(
+                "{\"messaging_product\":\"whatsapp\",\"to\":\"34600111222\","
+                        + "\"type\":\"text\",\"text\":{\"body\":\"\"}}",
+                requestBody(requestCaptor.getValue()));
+    }
+
+    @Test
+    void shouldRestoreInterruptedFlagWhenWhatsappSendIsInterrupted() throws Exception {
+        WhatsAppService service = new WhatsAppService(properties("api-token", "phone-id"), httpClient);
+        when(httpClient.send(any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+                .thenThrow(new InterruptedException("interrupted"));
+
+        assertFalse(Thread.currentThread().isInterrupted());
+
+        service.sendMessage("34600111222", "Hello");
+
+        assertTrue(Thread.currentThread().isInterrupted());
+        Thread.interrupted();
+    }
+
+    @Test
+    void shouldSwallowWhatsappIoExceptions() throws Exception {
+        WhatsAppService service = new WhatsAppService(properties("api-token", "phone-id"), httpClient);
+        when(httpClient.send(any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+                .thenThrow(new IOException("network down"));
+
+        service.sendMessage("34600111222", "Hello");
+
+        verify(httpClient).send(any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any());
+    }
+
+    private MessagingProperties properties(String token, String phoneNumberId) {
+        MessagingProperties properties = new MessagingProperties();
+        properties.getWhatsapp().setApiToken(token);
+        properties.getWhatsapp().setPhoneNumberId(phoneNumberId);
+        return properties;
+    }
+
+    private String requestBody(HttpRequest request) throws Exception {
+        HttpRequest.BodyPublisher publisher = request.bodyPublisher().orElseThrow();
+        BodyCollector subscriber = new BodyCollector();
+        publisher.subscribe(subscriber);
+        return subscriber.body();
+    }
+
+    private static final class BodyCollector implements Flow.Subscriber<ByteBuffer> {
+
+        private final StringBuilder body = new StringBuilder();
+        private final CompletableFuture<Void> done = new CompletableFuture<>();
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            subscription.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(ByteBuffer item) {
+            body.append(StandardCharsets.UTF_8.decode(item.duplicate()));
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            done.completeExceptionally(throwable);
+        }
+
+        @Override
+        public void onComplete() {
+            done.complete(null);
+        }
+
+        private String body() throws Exception {
+            done.get();
+            return body.toString();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add focused unit coverage for the backend messaging HTTP clients
- cover success, missing-token, API-error, IO, interruption, and JSON escaping paths
- keep runtime wiring intact by adding explicit constructor injection for the production constructors

## Validation
- cd backend && mvn -Dtest=MessagingServiceTest,TelegramServiceTest,WhatsAppServiceTest,TelegramWebhookControllerTest,WhatsAppWebhookControllerTest,WhatsAppWebhookHmacControllerTest test jacoco:report

Closes #364