### PR TITLE
fix(security): move backend runtime image to Temurin 21 noble

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -8,7 +8,7 @@ COPY config ../config
 RUN mvn package -DskipTests -q
 
 # Run stage
-FROM eclipse-temurin:25.0.2_10-jre-jammy
+FROM eclipse-temurin:21-jre-noble
 WORKDIR /app
 RUN useradd --system --create-home --uid 1001 appuser
 COPY --from=build --chmod=444 /app/target/*.jar app.jar


### PR DESCRIPTION
## Summary
- switch the backend runtime image from `eclipse-temurin:25.0.2_10-jre-jammy` to `eclipse-temurin:21-jre-noble`
- remove the Ubuntu 22.04 (`jammy`) base implicated by the new Snyk finding
- realign the runtime container with the project Java 21 baseline

## Verification
- confirmed `eclipse-temurin:21-jre-noble` exists in Docker Hub registry
- ran `mvn clean package -DskipTests` in `backend/`
- attempted `docker build -f docker/Dockerfile.backend .`, but Docker daemon was unavailable in this session

Closes #395
