### PR TITLE
chore(deps): update pending dashboard dependencies

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run Claude Code Review
         id: review
         continue-on-error: true
-        uses: anthropics/claude-code-action@e1f83b5b955a29fc3bab97ac514eabb778444dde # v1.0.79
+        uses: anthropics/claude-code-action@58dbe8ed6879f0d3b02ac295b20d5fdfe7733e0c # v1.0.85
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GH_CONFIG_TOKEN }}

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -247,7 +247,7 @@ jobs:
 
       - name: SonarCloud Scan
         if: steps.sonar-token.outputs.available == 'true'
-        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
+        uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7.1.0
         with:
           args: >
             -Dsonar.qualitygate.wait=false

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -160,7 +160,7 @@ jobs:
           test -f frontend/coverage/lcov.info
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
+        uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   backend:
     build:
@@ -64,7 +62,7 @@ services:
   # ── Observability Stack ─────────────────────────────────────────
 
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.148.0
+    image: otel/opentelemetry-collector-contrib:0.149.0
     command: ['--config=/etc/otel-collector-config.yml']
     ports:
       - '4317:4317' # OTLP gRPC

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6295,13 +6295,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -8574,9 +8574,9 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.1.tgz",
-      "integrity": "sha512-k1isifdbpNSFEHFJ1ZY4YDewv0IH9FR61lDetaRMD3j2ae3bIXGV+7c+LHCqtQGofSd8PIyV4X6+dHMAnSr60A==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.0.tgz",
+      "integrity": "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,9 +32,9 @@
     "lodash": "4.18.1",
     "picomatch@2.3.1": "2.3.2",
     "picomatch@4.0.3": "4.0.4",
-    "yauzl": "3.2.1",
+    "yauzl": "3.3.0",
     "editorconfig": {
-      "minimatch": "10.2.4"
+      "minimatch": "10.2.5"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- bump `SonarSource/sonarqube-scan-action` from `v7.0.0` to `v7.1.0` in the feature and verify workflows
- bump `anthropics/claude-code-action` from `v1.0.79` to `v1.0.85` in the code review workflow
- update frontend overrides so `minimatch` resolves to `10.2.5` and `yauzl` resolves to `3.3.0`
- bump `otel/opentelemetry-collector-contrib` from `0.148.0` to `0.149.0`
- remove the obsolete top-level `version` key from `docker/docker-compose.yml`

## Why
Issue #71 flagged these dependencies as outdated. The selected updates are patch/minor bumps that fit the repo's current usage without requiring code changes, and the compose cleanup removes an obsolete warning from Docker Compose v2.

## Validation
- `npm install --prefix frontend --package-lock-only`
- `npm install --prefix frontend`
- `npm --prefix frontend ls minimatch yauzl editorconfig cypress --all`
- `npm --prefix frontend run lint`
- `ruby -e "require 'yaml'; %w[.github/workflows/feature.yml .github/workflows/verify.yml .github/workflows/code-review.yml docker/docker-compose.yml].each { |f| YAML.load_file(f); puts \"#{f} OK\" }"`
- `docker compose -f docker/docker-compose.yml config`

Closes #71
