### PR TITLE
ci(code-review): add id-token permission and bump action to v1.0.89

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -9,6 +9,7 @@ permissions:
   actions: read
   checks: read
   contents: read
+  id-token: write
   pull-requests: write
 
 jobs:
@@ -26,7 +27,7 @@ jobs:
       - name: Run Claude Code Review
         id: review
         continue-on-error: true
-        uses: anthropics/claude-code-action@58dbe8ed6879f0d3b02ac295b20d5fdfe7733e0c # v1.0.85
+        uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GH_CONFIG_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `id-token: write` to `code-review.yml` permissions — `claude-code-action` requires OIDC token authentication and all code review checks were failing with "Could not fetch an OIDC token"
- Bump `claude-code-action` from v1.0.85 to v1.0.89 — includes a fix for token revocation when no token was acquired

**Note on Node.js 20 deprecation warning:** `oven-sh/setup-bun` (using Node.js 20) is a transitive dependency inside `claude-code-action`, not referenced in this repo — it can only be resolved upstream by Anthropic.

## Merging this PR

This PR itself will fail the **Code Review** required check on the first run (same bootstrap problem — the fix isn't active until merged). To merge:

### Option A — Temporarily remove "Code Review" from required checks (recommended)
```bash
# Save current contexts
gh api repos/lucasrudi/mindtrack/branches/main/protection --jq '.required_status_checks.contexts'

# Remove "Code Review" temporarily
gh api repos/lucasrudi/mindtrack/branches/main/protection \
  --method PUT \
  --field required_status_checks[strict]=true \
  --field 'required_status_checks[contexts][]=Backend Build & Test' \
  --field 'required_status_checks[contexts][]=Frontend Build & Test' \
  --field 'required_status_checks[contexts][]=Terraform Validate' \
  --field 'required_status_checks[contexts][]=Branch Name Check' \
  --field enforce_admins=true \
  --field required_pull_request_reviews=null \
  --field restrictions=null

# Merge this PR, then re-add "Code Review" to the contexts
```

### Option B — GitHub UI
Settings > Branches > main > Edit > temporarily uncheck **"Code Review"** from required checks > merge > re-add it.

After this PR merges, re-run the Code Review check on PR #407 — it should pass.

Closes #409