### PR TITLE
fix(infra): resolve RDS version drift, S3 MFA delete, and GitHub Pages deploy policy

### DIFF
--- a/infra/github-settings/main.tf
+++ b/infra/github-settings/main.tf
@@ -21,6 +21,12 @@ import {
   id = var.repository_name
 }
 
+# Import the github-pages environment created automatically by GitHub Pages.
+import {
+  to = module.github.github_repository_environment.github_pages
+  id = "${var.repository_name}:github-pages"
+}
+
 # Import GitHub's built-in labels that would otherwise conflict on create.
 import {
   for_each = toset(["bug", "documentation", "enhancement"])

--- a/infra/modules/github/main.tf
+++ b/infra/modules/github/main.tf
@@ -130,6 +130,21 @@ resource "github_actions_variable" "variables" {
 }
 
 # ------------------------------------
+# GitHub Pages Deployment Environment
+# Allows the deploy-docs job in deploy.yml to deploy from release tags
+# (e.g. backend-v*) in addition to the main branch.
+# ------------------------------------
+resource "github_repository_environment" "github_pages" {
+  repository  = github_repository.this.name
+  environment = "github-pages"
+
+  deployment_branch_policy {
+    protected_branches     = false
+    custom_branch_policies = false
+  }
+}
+
+# ------------------------------------
 # Private Vulnerability Reporting
 # ------------------------------------
 # The integrations/github Terraform provider v6.x does not expose private

--- a/infra/modules/rds/main.tf
+++ b/infra/modules/rds/main.tf
@@ -61,6 +61,12 @@ resource "aws_db_instance" "main" {
 
   allow_major_version_upgrade = true
 
+  # AWS auto-upgrades RDS minor versions; ignore drift to prevent Terraform
+  # from attempting a downgrade (e.g. 8.4.8 → 8.4.7) which AWS rejects.
+  lifecycle {
+    ignore_changes = [engine_version]
+  }
+
   performance_insights_enabled          = true
   performance_insights_kms_key_id       = aws_kms_key.rds.arn
   performance_insights_retention_period = 7 # free tier

--- a/infra/modules/s3/main.tf
+++ b/infra/modules/s3/main.tf
@@ -75,7 +75,7 @@ resource "aws_s3_bucket_versioning" "audio_versioning" {
 
   versioning_configuration {
     status     = "Enabled"
-    mfa_delete = "Enabled"
+    mfa_delete = "Disabled"
   }
 }
 
@@ -150,7 +150,7 @@ resource "aws_s3_bucket_versioning" "frontend_versioning" {
 
   versioning_configuration {
     status     = "Enabled"
-    mfa_delete = "Enabled"
+    mfa_delete = "Disabled"
   }
 }
 
@@ -303,7 +303,7 @@ resource "aws_s3_bucket_versioning" "access_logs_versioning" {
 
   versioning_configuration {
     status     = "Enabled"
-    mfa_delete = "Enabled"
+    mfa_delete = "Disabled"
   }
 }
 


### PR DESCRIPTION
## Summary

- **RDS engine_version drift**: Add `lifecycle { ignore_changes = [engine_version] }` to `aws_db_instance` — AWS auto-upgrades minor RDS versions; without this Terraform attempts to revert (e.g. 8.4.8 → 8.4.7) which AWS rejects as a downgrade
- **S3 MFA delete**: Change `mfa_delete` from `"Enabled"` to `"Disabled"` on all three S3 versioning resources (audio, frontend, access-logs) — enabling/disabling MFA delete requires a physical MFA device, which CI cannot satisfy; every `terraform apply` was failing with `AccessDenied`
- **GitHub Pages deploy policy**: Add `github_repository_environment` resource for `github-pages` with no branch restrictions so the `deploy-docs` job in `deploy.yml` can deploy from release tag events (`backend-v*`) in addition to the `main` branch; includes an `import` block since the environment already exists

## Test plan

- [ ] CI terraform validate passes
- [ ] After merge: `infra-v0.5.0` release triggers `deploy.yml` → `terraform apply` completes without RDS or S3 errors
- [ ] After merge: next `backend-v*` release triggers `deploy-docs` → docs deploy to GitHub Pages successfully

Closes #422