### PR TITLE
chore(security): document unremediable s3 mfa delete findings

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -26,4 +26,32 @@ ignore:
           design rather than add useful audit coverage. Revisit if we introduce
           a separate centralized audit-log archive bucket.
         expires: '2026-07-02T00:00:00.000Z'
+  SNYK-CC-TF-127:
+    - 'modules/s3/main.tf > resource > aws_s3_bucket_versioning[audio_versioning] > versioning_configuration > mfa_delete':
+        reason: >-
+          AWS documents that MFA Delete can only be enabled by the bucket owner
+          root account via CLI or API, and it cannot be used with S3 lifecycle
+          configurations. These buckets intentionally use lifecycle retention
+          rules, so this is not remediable as a normal Terraform change.
+          Revisit only if lifecycle policies are removed and a manual root-only
+          enablement process is acceptable.
+        expires: '2026-07-07T00:00:00.000Z'
+    - 'modules/s3/main.tf > resource > aws_s3_bucket_versioning[frontend_versioning] > versioning_configuration > mfa_delete':
+        reason: >-
+          AWS documents that MFA Delete can only be enabled by the bucket owner
+          root account via CLI or API, and it cannot be used with S3 lifecycle
+          configurations. These buckets intentionally use lifecycle retention
+          rules, so this is not remediable as a normal Terraform change.
+          Revisit only if lifecycle policies are removed and a manual root-only
+          enablement process is acceptable.
+        expires: '2026-07-07T00:00:00.000Z'
+    - 'modules/s3/main.tf > resource > aws_s3_bucket_versioning[access_logs_versioning] > versioning_configuration > mfa_delete':
+        reason: >-
+          AWS documents that MFA Delete can only be enabled by the bucket owner
+          root account via CLI or API, and it cannot be used with S3 lifecycle
+          configurations. These buckets intentionally use lifecycle retention
+          rules, so this is not remediable as a normal Terraform change.
+          Revisit only if lifecycle policies are removed and a manual root-only
+          enablement process is acceptable.
+        expires: '2026-07-07T00:00:00.000Z'
 patch: {}


### PR DESCRIPTION
## Summary
- carry over the authenticated Snyk IaC follow-up that landed after PR #439 had already merged
- add `.snyk` ignores for the three low-severity `SNYK-CC-TF-127` S3 MFA-delete findings
- keep the rationale explicit that AWS MFA Delete is root-account-only and incompatible with lifecycle configurations used by these buckets

## Validation
- `snyk iac test infra --policy-path=.snyk`

## Notes
- This PR is the missing follow-up from #439.
- Authenticated Snyk IaC test result on 2026-04-08: no vulnerable paths found, `Ignored issues: 5`, `Total issues: 0`.
- Snyk also reported the org has reached its monthly private-test limit, but the test itself completed successfully.

Closes #440