### PR TITLE
chore(deps): update all dependencies from Renovate dashboard

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run Claude Code Review
         id: review
         continue-on-error: true
-        uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89
+        uses: anthropics/claude-code-action@657fb7c9c986158a19624b357bcbc8c6deb83598 # v1.0.92
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GH_CONFIG_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,14 +65,14 @@ jobs:
 
       - name: Configure AWS credentials
         if: env.HAS_BOOTSTRAP_AWS_CREDS != 'true'
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Configure AWS credentials with admin bootstrap user
         if: env.HAS_BOOTSTRAP_AWS_CREDS == 'true'
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -166,14 +166,14 @@ jobs:
 
       - name: Configure AWS credentials
         if: env.HAS_BOOTSTRAP_AWS_CREDS != 'true'
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Configure AWS credentials with admin bootstrap user
         if: env.HAS_BOOTSTRAP_AWS_CREDS == 'true'
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -243,14 +243,14 @@ jobs:
 
       - name: Configure AWS credentials
         if: env.HAS_BOOTSTRAP_AWS_CREDS != 'true'
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Configure AWS credentials with admin bootstrap user
         if: env.HAS_BOOTSTRAP_AWS_CREDS == 'true'
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/github-config-sync.yml
+++ b/.github/workflows/github-config-sync.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -29,7 +29,7 @@
         <flyway.version>11.8.1</flyway.version>
 
         <!-- Sentry -->
-        <sentry.version>8.37.1</sentry.version>
+        <sentry.version>8.38.0</sentry.version>
 
         <!-- Sonar properties -->
         <sonar.organization>lucasrudi</sonar.organization>

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - mindtrack
 
   prometheus:
-    image: prom/prometheus:v3.11.0
+    image: prom/prometheus:v3.11.1
     ports:
       - '9090:9090'
     volumes:


### PR DESCRIPTION
## Summary
Batch update all dependencies with available updates from the Renovate Dependency Dashboard (#71).

- `anthropics/claude-code-action` `v1.0.89` → `v1.0.92` — `code-review.yml`
- `aws-actions/configure-aws-credentials` `v6.0.0` → `v6.1.0` — `deploy.yml` (×6), `github-config-sync.yml`
- `prom/prometheus` `v3.11.0` → `v3.11.1` — `docker/docker-compose.yml`
- `io.sentry:sentry-spring-jakarta` `8.37.1` → `8.38.0` — `backend/pom.xml`

Note: `axios ^1.15.0` was already updated in a previous merge.

## Test plan
- [ ] CI passes (backend build with updated Sentry SDK)
- [ ] No regressions in deploy/github-config-sync workflows (aws-actions bump is minor)

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)