### PR TITLE
fix(backend): remediate dependabot tomcat alerts

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -27,6 +27,8 @@
         <protobuf-java.version>4.34.1</protobuf-java.version>
         <!-- Override Flyway to fix SNYK-JAVA-COMFASTERXMLJACKSONCORE-15365924 (jackson-core via flyway-core 11.7.2) -->
         <flyway.version>11.8.1</flyway.version>
+        <!-- Spring Boot 4.0.5 still manages Tomcat 11.0.20; pin 11.0.21 to remediate current Dependabot alerts -->
+        <tomcat.version>11.0.21</tomcat.version>
 
         <!-- Sentry -->
         <sentry.version>8.38.0</sentry.version>


### PR DESCRIPTION
## Summary
Pins the backend Tomcat dependency to the first patched release so the current Dependabot alerts are resolved.

## Root cause
Spring Boot `4.0.5` currently manages `org.apache.tomcat.embed:tomcat-embed-core` at `11.0.20`, which is the vulnerable version behind the open alerts.

## What changed
- Added a `tomcat.version` override in `backend/pom.xml`
- Set the managed Tomcat version to `11.0.21`

## Validation
- Resolved `org.apache.tomcat.embed:tomcat-embed-core` to `11.0.21`
- Ran `mvn -f backend/pom.xml clean verify`

Closes #460
