### PR TITLE
ci(workflows): update action pins for review and artifacts

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1.0.93
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
@@ -41,4 +41,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run Claude Code Review
         id: review
         continue-on-error: true
-        uses: anthropics/claude-code-action@657fb7c9c986158a19624b357bcbc8c6deb83598 # v1.0.92
+        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1.0.93
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GH_CONFIG_TOKEN }}

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -84,13 +84,13 @@ jobs:
         run: mvn clean verify -B
 
       - name: Upload coverage
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: backend-coverage
           path: backend/target/site/jacoco/
 
       - name: Upload backend classes for Sonar
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: backend-classes
           path: backend/target/classes/
@@ -135,7 +135,7 @@ jobs:
         run: npm run build
 
       - name: Upload coverage
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: frontend-coverage
           path: frontend/coverage/

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -27,13 +27,13 @@ jobs:
         run: mvn clean verify -B
 
       - name: Upload coverage
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: backend-coverage
           path: backend/target/site/jacoco/
 
       - name: Upload backend classes for Sonar
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: backend-classes
           path: backend/target/classes/
@@ -70,7 +70,7 @@ jobs:
         run: npm run build
 
       - name: Upload coverage
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: frontend-coverage
           path: frontend/coverage/


### PR DESCRIPTION
## Summary
Updates the pinned GitHub Actions versions in the CI and Claude review workflows to the requested latest releases.

## What changed
- Updated `actions/upload-artifact` in `feature.yml` and `verify.yml` to `v7.0.1` (`043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`)
- Updated `anthropics/claude-code-action` in `code-review.yml` and `claude-code-review.yml` to `v1.0.93` (`b47fd721da662d48c5680e154ad16a73ed74d2e0`)
- Replaced the unpinned `@v1` reference in `claude-code-review.yml` with the exact commit SHA for deterministic builds

## Validation
- Confirmed the target SHAs from the official GitHub tags via `gh api`
- Parsed the edited workflow YAML files locally with Ruby `YAML.load_file`
- Ran `git diff --check`

Closes #465
