### PR TITLE
ci(github): add fallback dependency submission triggers

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'backend/pom.xml'
       - 'backend/**/pom.xml'
+  workflow_dispatch:
+  schedule:
+    - cron: '23 5 * * *'
 
 permissions:
   contents: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ Commit/PR title format: `type(scope): description` — standard Conventional Com
 | Daily Clean Build | `daily-verify.yml` | Daily 04:00 UTC; manual | Clean build with `mvn verify -U` (no cache) to catch dependency drift |
 | Snyk Weekly Security | `snyk-monitor.yml` | Monday 03:00 UTC; manual | Snyk test (high-severity gate) + monitor for backend and frontend |
 | Renovate | `renovate.yml` | Daily 06:00 UTC; manual | Renovate bot creates dependency update PRs using `GH_CONFIG_TOKEN` |
-| Dependency Submission | `dependency-submission.yml` | Push to `main` with `pom.xml` changes | Submits Maven deps to GitHub Dependency Graph for Dependabot alerts |
+| Dependency Submission | `dependency-submission.yml` | Push to `main` with `pom.xml` changes; daily 05:23 UTC; manual | Submits Maven deps to GitHub Dependency Graph for Dependabot alerts |
 | GitHub Config Sync | `github-config-sync.yml` | Push to `infra/github-settings/`; daily 06:00 UTC; manual | Terraform apply for repo settings (branch protection, required checks) |
 
 **Required secrets:** `ANTHROPIC_API_KEY` (code review), `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` (GitHub config sync), `SNYK_TOKEN`, `SONAR_TOKEN`.

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -45,7 +45,7 @@ flowchart TD
 
         VER["verify.yml — Verify\nbackend + frontend + infra + sonar"]
         REL["release.yml — Release Please\ncreates/updates release PRs"]
-        DS["dependency-submission.yml\npom.xml changes only"]
+        DS["dependency-submission.yml\npom.xml changes + daily fallback + manual"]
         GCS_PUSH["github-config-sync.yml\ninfra/github-settings changes"]
 
         MAIN --> VER & REL & DS & GCS_PUSH
@@ -266,10 +266,12 @@ Uses `secrets.GH_CONFIG_TOKEN` (a PAT) rather than the default `GITHUB_TOKEN` be
 
 ### Dependency Submission (`dependency-submission.yml`)
 
-**Trigger:** Push to `main` when `backend/pom.xml` or any `backend/**/pom.xml` changes
+**Trigger:** Push to `main` when `backend/pom.xml` or any `backend/**/pom.xml` changes; daily at `05:23 UTC`; manual
 **Purpose:** Submit the Maven dependency graph to GitHub for Dependabot alerts.
 
 Uses the `advanced-security/maven-dependency-submission-action` to populate the GitHub Dependency Graph, enabling Dependabot security alerts for the backend.
+
+The daily fallback and manual trigger keep the dependency graph fresh even if a qualifying `push` event is missed or GitHub needs a resubmission after a security-only remediation.
 
 | Job | Steps |
 |-----|-------|


### PR DESCRIPTION
## Summary
- add manual and daily fallback triggers to the backend dependency submission workflow
- update workflow documentation so the repo docs match the actual trigger behavior
- make it easier for GitHub to refresh the Maven dependency graph after security remediations

## Root cause
The backend Tomcat remediation is already present on `main`, and Maven resolves `org.apache.tomcat.embed:tomcat-embed-core` to `11.0.21`. However, `dependency-submission.yml` only ran on `push` events that touched backend Maven manifests, which made it easy for GitHub's dependency graph to stay stale and keep Dependabot alerts open.

## Validation
- parsed `.github/workflows/dependency-submission.yml` successfully with Ruby YAML
- confirmed Maven resolves `tomcat-embed-core` to `11.0.21`
- pushed this branch and opened this PR

Closes #467
