### PR TITLE
test(messaging): cover invalid-input branches in messaging services

### DIFF
--- a/backend/src/test/java/com/mindtrack/messaging/service/MessagingServiceTest.java
+++ b/backend/src/test/java/com/mindtrack/messaging/service/MessagingServiceTest.java
@@ -125,6 +125,33 @@ class MessagingServiceTest {
     }
 
     @Test
+    void shouldIgnoreTelegramMessageWhenInboundChatIdIsTooShort() {
+        TelegramUpdate update = new TelegramUpdate();
+        update.setUpdateId(1L);
+
+        TelegramUpdate.TelegramMessage message = new TelegramUpdate.TelegramMessage();
+        message.setMessageId(1L);
+        message.setText("Hello");
+
+        TelegramUpdate.TelegramChat chat = new TelegramUpdate.TelegramChat();
+        chat.setId(123L); // 3 digits — too short for the pattern ^-?\d{5,20}$
+        chat.setType("private");
+        message.setChat(chat);
+
+        TelegramUpdate.TelegramUser from = new TelegramUpdate.TelegramUser();
+        from.setId(123L);
+        from.setFirstName("Test");
+        message.setFrom(from);
+
+        update.setMessage(message);
+
+        messagingService.handleTelegramMessage(update);
+
+        verify(telegramService, never()).sendMessage(any(), any());
+        verify(conversationService, never()).chatWithChannel(any(), any(), any());
+    }
+
+    @Test
     void shouldIgnoreTelegramMessageWhenStoredChatIdIsInvalid() {
         TelegramUpdate update = createTelegramUpdate("12345", "Check in");
 
@@ -193,6 +220,16 @@ class MessagingServiceTest {
         messagingService.handleWhatsAppMessage(webhook);
 
         verify(whatsAppService).sendMessage(eq("+1234567890"), any(String.class));
+    }
+
+    @Test
+    void shouldIgnoreWhatsAppMessageWithInvalidIncomingPhoneNumber() {
+        WhatsAppWebhook webhook = createWhatsAppWebhook("not-a-phone", "Hello");
+
+        messagingService.handleWhatsAppMessage(webhook);
+
+        verify(userProfileRepository, never()).findAllByWhatsappNumberNotNull();
+        verify(whatsAppService, never()).sendMessage(any(), any());
     }
 
     @Test

--- a/backend/src/test/java/com/mindtrack/messaging/service/TelegramServiceTest.java
+++ b/backend/src/test/java/com/mindtrack/messaging/service/TelegramServiceTest.java
@@ -114,6 +114,24 @@ class TelegramServiceTest {
         verify(httpClient).send(any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any());
     }
 
+    @Test
+    void shouldSkipSendWhenChatIdIsTooShort() throws Exception {
+        TelegramService service = new TelegramService(propertiesWithTelegramToken("bot-token"), httpClient);
+
+        service.sendMessage("123", "Hello");
+
+        verify(httpClient, never()).send(any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any());
+    }
+
+    @Test
+    void shouldSkipSendWhenChatIdIsNonNumeric() throws Exception {
+        TelegramService service = new TelegramService(propertiesWithTelegramToken("bot-token"), httpClient);
+
+        service.sendMessage("not-a-chat-id", "Hello");
+
+        verify(httpClient, never()).send(any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any());
+    }
+
     private MessagingProperties propertiesWithTelegramToken(String token) {
         MessagingProperties properties = new MessagingProperties();
         properties.getTelegram().setBotToken(token);

--- a/backend/src/test/java/com/mindtrack/messaging/service/WhatsAppServiceTest.java
+++ b/backend/src/test/java/com/mindtrack/messaging/service/WhatsAppServiceTest.java
@@ -117,6 +117,24 @@ class WhatsAppServiceTest {
         verify(httpClient).send(any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any());
     }
 
+    @Test
+    void shouldSkipSendWhenPhoneNumberIsTooShort() throws Exception {
+        WhatsAppService service = new WhatsAppService(properties("api-token", "phone-id"), httpClient);
+
+        service.sendMessage("1234", "Hello");
+
+        verify(httpClient, never()).send(any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any());
+    }
+
+    @Test
+    void shouldSkipSendWhenPhoneNumberIsNonNumeric() throws Exception {
+        WhatsAppService service = new WhatsAppService(properties("api-token", "phone-id"), httpClient);
+
+        service.sendMessage("not-a-phone", "Hello");
+
+        verify(httpClient, never()).send(any(HttpRequest.class), ArgumentMatchers.<HttpResponse.BodyHandler<String>>any());
+    }
+
     private MessagingProperties properties(String token, String phoneNumberId) {
         MessagingProperties properties = new MessagingProperties();
         properties.getWhatsapp().setApiToken(token);


### PR DESCRIPTION
## Summary

- Add `shouldSkipSendWhenChatIdIsTooShort` and `shouldSkipSendWhenChatIdIsNonNumeric` to `TelegramServiceTest` — covers the guard that skips the HTTP send when the chat ID doesn't match `^-?\d{5,20}$`
- Add `shouldSkipSendWhenPhoneNumberIsTooShort` and `shouldSkipSendWhenPhoneNumberIsNonNumeric` to `WhatsAppServiceTest` — covers the guard that skips the HTTP send when the phone number is invalid
- Add `shouldIgnoreTelegramMessageWhenInboundChatIdIsTooShort` to `MessagingServiceTest` — covers the early-return at line 72 of `MessagingService` when the inbound Telegram chat ID sanitises to null
- Add `shouldIgnoreWhatsAppMessageWithInvalidIncomingPhoneNumber` to `MessagingServiceTest` — covers the early-return at line 168 when the inbound WhatsApp phone number sanitises to null

## Motivation

The SonarCloud quality gate on `main` failed (new-code coverage 78.9% < threshold 80%) after the messaging services were modified. These six tests cover the previously untested sanitisation guards and push new-code coverage above the threshold.

## Test plan

- [x] `mvn test -Dtest=MessagingServiceTest,TelegramServiceTest,WhatsAppServiceTest` — 35 tests, 0 failures

Closes #501