### PR TITLE
fix(security): bump spring-framework to 7.0.7 to remediate CVE-2026-22741

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -29,6 +29,9 @@
         <flyway.version>11.8.1</flyway.version>
         <!-- Spring Boot 4.0.5 still manages Tomcat 11.0.20; pin 11.0.21 to remediate current Dependabot alerts -->
         <tomcat.version>11.0.21</tomcat.version>
+        <!-- Override Spring Framework to fix SNYK-JAVA-ORGSPRINGFRAMEWORK-16109603 / CVE-2026-22741
+             (spring-webmvc resource cache poisoning; fixed in 7.0.7). Spring Boot 4.0.5 manages 7.0.6. -->
+        <spring-framework.version>7.0.7</spring-framework.version>
 
         <!-- Sentry -->
         <sentry.version>8.39.1</sentry.version>


### PR DESCRIPTION
## Summary

- Overrides `spring-framework.version` from `7.0.6` → `7.0.7` in `backend/pom.xml`
- Remediates **SNYK-JAVA-ORGSPRINGFRAMEWORK-16109603** / **CVE-2026-22741** (Low, CVSS 2.3): resource cache poisoning in `spring-webmvc` via crafted encoded-resource requests
- Follows the same targeted-property-override pattern used for prior CVE remediations (netty, protobuf, flyway, tomcat)
- All Spring Framework artifacts (`spring-core`, `spring-web`, `spring-webmvc`, `spring-context`, `spring-tx`, …) automatically cascade to 7.0.7 via the Boot BOM

## Test plan

- [x] `mvn -q help:evaluate -Dexpression=spring-framework.version` → `7.0.7`
- [x] `spring-webmvc:jar:7.0.7:compile` confirmed in dependency tree
- [x] `mvn clean verify` — BUILD SUCCESS

Closes #507